### PR TITLE
Support type inference

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -61,6 +61,8 @@ export default class LLVMCodeGen {
         return this.genStatement(node as ts.Statement);
       case ts.SyntaxKind.IfStatement:
         return this.genStatement(node as ts.Statement);
+      case ts.SyntaxKind.ForStatement:
+        return this.genStatement(node as ts.Statement);
       case ts.SyntaxKind.ReturnStatement:
         return this.genStatement(node as ts.Statement);
       case ts.SyntaxKind.FunctionDeclaration:
@@ -324,8 +326,14 @@ export default class LLVMCodeGen {
   public genVariableDeclaration(node: ts.VariableDeclaration): llvm.Value {
     const name = node.name.getText();
     const initializer = this.genExpression(node.initializer!);
-    const type = this.genType(node.type!);
-
+    const type = (() => {
+      // Type inferences
+      if (node.type) {
+        return this.genType(node.type);
+      } else {
+        return initializer.type;
+      }
+    })();
     if (this.symtab.depths() === 0) {
       // Global variables
       const r = new llvm.GlobalVariable(

--- a/tests/ts/type_inference.ts
+++ b/tests/ts/type_inference.ts
@@ -1,0 +1,5 @@
+function main(): number {
+    let a = 10; // Skip the annotation type
+    let b: number = 20;
+    return a + b;
+}


### PR DESCRIPTION
Add a simple type inference

```
let a: number = 10; [OK]
let b = 10;         [OK], b is treated as number automatically
```