### PR TITLE
Implement system call

### DIFF
--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -1,7 +1,6 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import Stdlib from '../stdlib';
 import LLVMCodeGen from './';
 
 export default class CodeGenFuncDecl {
@@ -19,10 +18,10 @@ export default class CodeGenFuncDecl {
     let func: llvm.Constant;
     switch (name) {
       case 'console.log':
-        func = this.cgen.module.getOrInsertFunction('printf', Stdlib.printf(this.cgen));
+        func = this.cgen.module.getOrInsertFunction('printf', this.cgen.stdlib.printf());
         break;
       case 'strcmp':
-        func = this.cgen.module.getOrInsertFunction('strcmp', Stdlib.strcmp(this.cgen));
+        func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
         break;
       default:
         func = this.cgen.module.getFunction(name)!;

--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -20,8 +20,14 @@ export default class CodeGenFuncDecl {
       case 'console.log':
         func = this.cgen.module.getOrInsertFunction('printf', this.cgen.stdlib.printf());
         break;
+      case 'printf':
+        func = this.cgen.module.getOrInsertFunction('printf', this.cgen.stdlib.printf());
+        break;
       case 'strcmp':
         func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
+        break;
+      case 'syscall':
+        func = this.cgen.module.getOrInsertFunction('syscall', this.cgen.stdlib.syscall());
         break;
       default:
         func = this.cgen.module.getFunction(name)!;

--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -1,0 +1,33 @@
+import llvm from 'llvm-node';
+import ts from 'typescript';
+
+import Stdlib from '../stdlib';
+import LLVMCodeGen from './';
+
+export default class CodeGenFuncDecl {
+  private cgen: LLVMCodeGen;
+
+  constructor(cgen: LLVMCodeGen) {
+    this.cgen = cgen;
+  }
+
+  public genCallExpression(node: ts.CallExpression): llvm.Value {
+    const name = node.expression.getText();
+    const args = node.arguments.map(item => {
+      return this.cgen.genExpression(item);
+    });
+    let func: llvm.Constant;
+    switch (name) {
+      case 'console.log':
+        func = this.cgen.module.getOrInsertFunction('printf', Stdlib.printf(this.cgen));
+        break;
+      case 'strcmp':
+        func = this.cgen.module.getOrInsertFunction('strcmp', Stdlib.strcmp(this.cgen));
+        break;
+      default:
+        func = this.cgen.module.getFunction(name)!;
+        break;
+    }
+    return this.cgen.builder.createCall(func, args);
+  }
+}

--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -12,29 +12,19 @@ export default class CodeGenFuncDecl {
 
   public genCallExpression(node: ts.CallExpression): llvm.Value {
     const name = node.expression.getText();
-    let args = node.arguments.map(item => {
+    const args = node.arguments.map(item => {
       return this.cgen.genExpression(item);
     });
     let func: llvm.Constant;
     switch (name) {
       case 'console.log':
-        func = this.cgen.module.getOrInsertFunction('printf', this.cgen.stdlib.printf());
-        break;
+        return this.cgen.stdlib.printf(args);
       case 'printf':
-        func = this.cgen.module.getOrInsertFunction('printf', this.cgen.stdlib.printf());
-        break;
+        return this.cgen.stdlib.printf(args);
       case 'strcmp':
-        func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
-        break;
+        return this.cgen.stdlib.strcmp(args);
       case 'syscall':
-        func = this.cgen.module.getOrInsertFunction('syscall', this.cgen.stdlib.syscall());
-        args = args.map(item => {
-          if (item.type.isPointerTy()) {
-            return this.cgen.builder.createPtrToInt(item, llvm.Type.getInt64Ty(this.cgen.context));
-          }
-          return item;
-        });
-        break;
+        return this.cgen.stdlib.syscall(args);
       default:
         func = this.cgen.module.getFunction(name)!;
         break;

--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -12,7 +12,7 @@ export default class CodeGenFuncDecl {
 
   public genCallExpression(node: ts.CallExpression): llvm.Value {
     const name = node.expression.getText();
-    const args = node.arguments.map(item => {
+    let args = node.arguments.map(item => {
       return this.cgen.genExpression(item);
     });
     let func: llvm.Constant;
@@ -28,6 +28,12 @@ export default class CodeGenFuncDecl {
         break;
       case 'syscall':
         func = this.cgen.module.getOrInsertFunction('syscall', this.cgen.stdlib.syscall());
+        args = args.map(item => {
+          if (item.type.isPointerTy()) {
+            return this.cgen.builder.createPtrToInt(item, llvm.Type.getInt64Ty(this.cgen.context));
+          }
+          return item;
+        });
         break;
       default:
         func = this.cgen.module.getFunction(name)!;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2,6 +2,7 @@ import Debug from 'debug';
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
+import Stdlib from '../stdlib';
 import Symtab from '../symtab';
 import { StructMeta, StructMetaType } from '../types';
 import CodeGenArray from './array-literal-expression';
@@ -29,6 +30,7 @@ export default class LLVMCodeGen {
   public readonly context: llvm.LLVMContext;
   public readonly module: llvm.Module;
   public readonly symtab: Symtab;
+  public readonly stdlib: Stdlib;
   public readonly structTab: Map<string, StructMeta>;
 
   public readonly cgArray: CodeGenArray;
@@ -57,6 +59,7 @@ export default class LLVMCodeGen {
     this.module = new llvm.Module('main', this.context);
     this.builder = new llvm.IRBuilder(this.context);
     this.symtab = new Symtab();
+    this.stdlib = new Stdlib(this);
     this.structTab = new Map();
 
     this.cgArray = new CodeGenArray(this);

--- a/src/codegen/string-literal-expression.ts
+++ b/src/codegen/string-literal-expression.ts
@@ -39,14 +39,12 @@ export default class CodeGenString {
   }
 
   public eq(lhs: llvm.Value, rhs: llvm.Value): llvm.Value {
-    const func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
-    const r = this.cgen.builder.createCall(func, [lhs, rhs]);
+    const r = this.cgen.stdlib.strcmp([lhs, rhs]);
     return this.cgen.builder.createICmpEQ(r, llvm.ConstantInt.get(this.cgen.context, 0, 64));
   }
 
   public ne(lhs: llvm.Value, rhs: llvm.Value): llvm.Value {
-    const func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
-    const r = this.cgen.builder.createCall(func, [lhs, rhs]);
+    const r = this.cgen.stdlib.strcmp([lhs, rhs]);
     return this.cgen.builder.createICmpNE(r, llvm.ConstantInt.get(this.cgen.context, 0, 64));
   }
 }

--- a/src/codegen/string-literal-expression.ts
+++ b/src/codegen/string-literal-expression.ts
@@ -2,7 +2,6 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import Stdlib from '../stdlib';
 import LLVMCodeGen from './';
 
 export default class CodeGenString {
@@ -40,13 +39,13 @@ export default class CodeGenString {
   }
 
   public eq(lhs: llvm.Value, rhs: llvm.Value): llvm.Value {
-    const func = this.cgen.module.getOrInsertFunction('strcmp', Stdlib.strcmp(this.cgen));
+    const func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
     const r = this.cgen.builder.createCall(func, [lhs, rhs]);
     return this.cgen.builder.createICmpEQ(r, llvm.ConstantInt.get(this.cgen.context, 0, 64));
   }
 
   public ne(lhs: llvm.Value, rhs: llvm.Value): llvm.Value {
-    const func = this.cgen.module.getOrInsertFunction('strcmp', Stdlib.strcmp(this.cgen));
+    const func = this.cgen.module.getOrInsertFunction('strcmp', this.cgen.stdlib.strcmp());
     const r = this.cgen.builder.createCall(func, [lhs, rhs]);
     return this.cgen.builder.createICmpNE(r, llvm.ConstantInt.get(this.cgen.context, 0, 64));
   }

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -3,14 +3,24 @@ import llvm from 'llvm-node';
 import LLVMCodeGen from '../codegen';
 
 export default class Stdlib {
-  public static printf(cgen: LLVMCodeGen): llvm.FunctionType {
-    return llvm.FunctionType.get(llvm.Type.getInt64Ty(cgen.context), [llvm.Type.getInt8PtrTy(cgen.context)], true);
+  private cgen: LLVMCodeGen;
+
+  constructor(cgen: LLVMCodeGen) {
+    this.cgen = cgen;
   }
 
-  public static strcmp(cgen: LLVMCodeGen): llvm.FunctionType {
+  public printf(): llvm.FunctionType {
     return llvm.FunctionType.get(
-      llvm.Type.getInt64Ty(cgen.context),
-      [llvm.Type.getInt8PtrTy(cgen.context), llvm.Type.getInt8PtrTy(cgen.context)],
+      llvm.Type.getInt64Ty(this.cgen.context),
+      [llvm.Type.getInt8PtrTy(this.cgen.context)],
+      true
+    );
+  }
+
+  public strcmp(): llvm.FunctionType {
+    return llvm.FunctionType.get(
+      llvm.Type.getInt64Ty(this.cgen.context),
+      [llvm.Type.getInt8PtrTy(this.cgen.context), llvm.Type.getInt8PtrTy(this.cgen.context)],
       false
     );
   }

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -24,4 +24,20 @@ export default class Stdlib {
       false
     );
   }
+
+  public syscall(): llvm.FunctionType {
+    return llvm.FunctionType.get(
+      llvm.Type.getInt64Ty(this.cgen.context),
+      [
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context)
+      ],
+      false
+    );
+  }
 }

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -9,35 +9,49 @@ export default class Stdlib {
     this.cgen = cgen;
   }
 
-  public printf(): llvm.FunctionType {
-    return llvm.FunctionType.get(
-      llvm.Type.getInt64Ty(this.cgen.context),
-      [llvm.Type.getInt8PtrTy(this.cgen.context)],
-      true
+  public printf(args: llvm.Value[]): llvm.Value {
+    const func = this.cgen.module.getOrInsertFunction(
+      'printf',
+      llvm.FunctionType.get(llvm.Type.getInt64Ty(this.cgen.context), [llvm.Type.getInt8PtrTy(this.cgen.context)], true)
     );
+    return this.cgen.builder.createCall(func, args);
   }
 
-  public strcmp(): llvm.FunctionType {
-    return llvm.FunctionType.get(
-      llvm.Type.getInt64Ty(this.cgen.context),
-      [llvm.Type.getInt8PtrTy(this.cgen.context), llvm.Type.getInt8PtrTy(this.cgen.context)],
-      false
+  public strcmp(args: llvm.Value[]): llvm.Value {
+    const func = this.cgen.module.getOrInsertFunction(
+      'strcmp',
+      llvm.FunctionType.get(
+        llvm.Type.getInt64Ty(this.cgen.context),
+        [llvm.Type.getInt8PtrTy(this.cgen.context), llvm.Type.getInt8PtrTy(this.cgen.context)],
+        false
+      )
     );
+    return this.cgen.builder.createCall(func, args);
   }
 
-  public syscall(): llvm.FunctionType {
-    return llvm.FunctionType.get(
-      llvm.Type.getInt64Ty(this.cgen.context),
-      [
+  public syscall(args: llvm.Value[]): llvm.Value {
+    const func = this.cgen.module.getOrInsertFunction(
+      'strcmp',
+      llvm.FunctionType.get(
         llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context),
-        llvm.Type.getInt64Ty(this.cgen.context)
-      ],
-      false
+        [
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context),
+          llvm.Type.getInt64Ty(this.cgen.context)
+        ],
+        false
+      )
     );
+    const argl = args.map(item => {
+      if (item.type.isPointerTy()) {
+        return this.cgen.builder.createPtrToInt(item, llvm.Type.getInt64Ty(this.cgen.context));
+      }
+      return item;
+    });
+    return this.cgen.builder.createCall(func, argl);
   }
 }

--- a/src/stdlib/syscall.ll
+++ b/src/stdlib/syscall.ll
@@ -1,0 +1,65 @@
+; ModuleID = 'syscall.c'
+source_filename = "syscall.c"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-unknown-elf"
+
+; Function Attrs: noinline nounwind optnone
+define dso_local i64 @syscall(i64 %n, i64 %_a0, i64 %_a1, i64 %_a2, i64 %_a3, i64 %_a4, i64 %_a5) #0 {
+entry:
+  %n.addr = alloca i64, align 8
+  %_a0.addr = alloca i64, align 8
+  %_a1.addr = alloca i64, align 8
+  %_a2.addr = alloca i64, align 8
+  %_a3.addr = alloca i64, align 8
+  %_a4.addr = alloca i64, align 8
+  %_a5.addr = alloca i64, align 8
+  %a0 = alloca i64, align 8
+  %a1 = alloca i64, align 8
+  %a2 = alloca i64, align 8
+  %a3 = alloca i64, align 8
+  %a4 = alloca i64, align 8
+  %a5 = alloca i64, align 8
+  %syscall_id = alloca i64, align 8
+  store i64 %n, i64* %n.addr, align 8
+  store i64 %_a0, i64* %_a0.addr, align 8
+  store i64 %_a1, i64* %_a1.addr, align 8
+  store i64 %_a2, i64* %_a2.addr, align 8
+  store i64 %_a3, i64* %_a3.addr, align 8
+  store i64 %_a4, i64* %_a4.addr, align 8
+  store i64 %_a5, i64* %_a5.addr, align 8
+  %0 = load i64, i64* %_a0.addr, align 8
+  store i64 %0, i64* %a0, align 8
+  %1 = load i64, i64* %_a1.addr, align 8
+  store i64 %1, i64* %a1, align 8
+  %2 = load i64, i64* %_a2.addr, align 8
+  store i64 %2, i64* %a2, align 8
+  %3 = load i64, i64* %_a3.addr, align 8
+  store i64 %3, i64* %a3, align 8
+  %4 = load i64, i64* %_a4.addr, align 8
+  store i64 %4, i64* %a4, align 8
+  %5 = load i64, i64* %_a5.addr, align 8
+  store i64 %5, i64* %a5, align 8
+  %6 = load i64, i64* %n.addr, align 8
+  store i64 %6, i64* %syscall_id, align 8
+  %7 = load i64, i64* %a0, align 8
+  %8 = load i64, i64* %a1, align 8
+  %9 = load i64, i64* %a2, align 8
+  %10 = load i64, i64* %a3, align 8
+  %11 = load i64, i64* %a4, align 8
+  %12 = load i64, i64* %a5, align 8
+  %13 = load i64, i64* %syscall_id, align 8
+  %14 = call i64 asm sideeffect "scall", "={x10},{x11},{x12},{x13},{x14},{x15},{x17},0"(i64 %8, i64 %9, i64 %10, i64 %11, i64 %12, i64 %13, i64 %7) #1, !srcloc !2
+  store i64 %14, i64* %a0, align 8
+  %15 = load i64, i64* %a0, align 8
+  ret i64 %15
+}
+
+attributes #0 = { noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+relax" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 10.0.0 (https://github.com/llvm/llvm-project.git 3d68adebc579720a3914d50e77a413773be34f16)"}
+!2 = !{i32 375}


### PR DESCRIPTION
Since `llvm-node` have't support `InlineAsm`(https://github.com/MichaReiser/llvm-node/issues/94), I have to use c code to achieve this. Everythings goes well, except that it is complicated to use.

# Sources files

```
$ cat syscall.c
```

```c
long syscall(long n, long _a0, long _a1, long _a2, long _a3, long _a4, long _a5)
{
    register long a0 asm("a0") = _a0;
    register long a1 asm("a1") = _a1;
    register long a2 asm("a2") = _a2;
    register long a3 asm("a3") = _a3;
    register long a4 asm("a4") = _a4;
    register long a5 asm("a5") = _a5;
    register long syscall_id asm("a7") = n;
    asm volatile ("scall": "+r"(a0) : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
    return a0;
}
```

```
$ cat main.ts
```

```ts
function main(): number {
    let a = "Hello World!";
    return syscall(2177, a, 0, 0, 0, 0, 0);
}
```

# Compile the main.ts with syscall

```
$ /usr/local/llvm-riscv/bin/clang -target riscv64-unknown-elf -emit-llvm -S syscall.c -o syscall.ll
$ ts-node src/index.ts build main.ts -o main.ll --triple riscv64-unknown-unknown-elf

$ /usr/local/llvm-riscv/bin/llvm-as syscall.ll -o syscall.bc
$ /usr/local/llvm-riscv/bin/llvm-as main.ll -o main.bc
$ /usr/local/llvm-riscv/bin/llvm-link main.bc syscall.bc -o echo.bc
$ /usr/local/llvm-riscv/bin/llc -filetype=obj echo.bc
$ /usr/local/riscv/bin/riscv64-unknown-elf-gcc echo.o -o echo.out
```

# Run it on `cita-vm`

![snap](https://user-images.githubusercontent.com/12387889/63763920-449b8c00-c8f8-11e9-86e2-9c220b3cda95.png)

