### PR TITLE
feat: Support object literal.

### DIFF
--- a/src/codegen/enum-declaration.ts
+++ b/src/codegen/enum-declaration.ts
@@ -5,7 +5,7 @@ import ts from 'typescript';
 import { StructMetaType } from '../types';
 import LLVMCodeGen from './';
 
-const debug = Debug('minits:codegen:struct');
+const debug = Debug('minits:codegen:enum');
 
 debug('codegen-enum');
 
@@ -23,7 +23,7 @@ export default class CodeGenStruct {
     const enumType = llvm.StructType.create(this.cgen.context, enumName);
     enumType.setBody([enumMemberType]);
 
-    this.cgen.structTab.set(enumName, { metaType: StructMetaType.Enum, fields: new Map() });
+    this.cgen.structTab.set(enumName, { metaType: StructMetaType.Enum, struct: enumType });
   }
 
   public genEnumElementAccess(node: ts.PropertyAccessExpression): llvm.Value {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -14,13 +14,13 @@ import CodeGenForOf from './for-of-statement';
 import CodeGenFor from './for-statement';
 import CodeGenFuncDecl from './function-declaration';
 import CodeGenIf from './if-statement';
+import CodeGenObject from './object-declaration';
 import CodeGenPostfixUnary from './postfix-unary-expression';
 import CodeGenPrefixUnary from './prefix-unary-expression';
 import CodeGenReturn from './return-statement';
 import CodeGenString from './string-literal-expression';
 import CodeGenVarDecl from './variable-declaration';
 import CodeGenWhile from './while-statement';
-import CodeGenObject from './object-declaration';
 
 const debug = Debug('minits:codegen');
 

--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -2,9 +2,9 @@ import Debug from 'debug';
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import LLVMCodeGen from './';
-import { StructMeta, StructMetaType } from '../types';
 import { genTypesHash } from '../common';
+import { StructMeta, StructMetaType } from '../types';
+import LLVMCodeGen from './';
 
 const debug = Debug('minits:codegen:object');
 
@@ -42,8 +42,7 @@ export default class GenObject {
       const structType = llvm.StructType.create(this.cgen.context, typeHash);
       structType.setBody(types, false);
 
-      const structMeta: StructMeta = { metaType: StructMetaType.Class, typeHash, struct: structType };
-      this.cgen.structTab.set(typeHash, structMeta);
+      this.cgen.structTab.set(typeHash, { metaType: StructMetaType.Class, typeHash, struct: structType });
     }
 
     const structMeta = this.cgen.structTab.get(typeHash)!;

--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -1,0 +1,85 @@
+import Debug from 'debug';
+import llvm from 'llvm-node';
+import ts from 'typescript';
+
+import LLVMCodeGen from './';
+import { StructMeta, StructMetaType } from '../types';
+import { genTypesHash } from '../common';
+
+const debug = Debug('minits:codegen:object');
+
+debug('codegen-object');
+
+export default class GenObject {
+  private cgen: LLVMCodeGen;
+
+  constructor(cgen: LLVMCodeGen) {
+    this.cgen = cgen;
+  }
+
+  public genObjectLiteralExpression(node: ts.ObjectLiteralExpression): llvm.Value {
+    const kinds = [];
+    const values: llvm.Value[] = [];
+    const types = [];
+
+    for (const p of node.properties) {
+      if (ts.isPropertyAssignment(p)) {
+        const init = p.initializer;
+
+        kinds.push(init.kind);
+
+        const value = this.genPropertyAssignment(p);
+        values.push(value);
+        types.push(value.type);
+      } else {
+        throw new Error('Unsupported assignments');
+      }
+    }
+
+    const typeHash = genTypesHash(types);
+
+    if (!this.cgen.structTab.get(typeHash)) {
+      const structType = llvm.StructType.create(this.cgen.context, typeHash);
+      structType.setBody(types, false);
+
+      const structMeta: StructMeta = { metaType: StructMetaType.Class, typeHash, struct: structType };
+      this.cgen.structTab.set(typeHash, structMeta);
+    }
+
+    const structMeta = this.cgen.structTab.get(typeHash)!;
+
+    return this.genObjectInst(structMeta.struct, values as llvm.Constant[]);
+  }
+
+  public genObjectElementAccess(node: ts.PropertyAccessExpression): llvm.Value {
+    const { value, fields } = this.cgen.symtab.get(node.expression.getText());
+    const field = node.name.getText();
+    const index = fields!.get(field)!;
+
+    const ptr = this.cgen.builder.createInBoundsGEP(value, [
+      llvm.ConstantInt.get(this.cgen.context, 0, 32, true),
+      llvm.ConstantInt.get(this.cgen.context, index, 32, true)
+    ]);
+    return this.cgen.builder.createLoad(ptr);
+  }
+
+  private genObjectInst(struct: llvm.StructType, values: llvm.Constant[]): llvm.Value {
+    if (this.cgen.symtab.isGlobal()) {
+      return new llvm.GlobalVariable(
+        this.cgen.module,
+        struct,
+        false,
+        llvm.LinkageTypes.ExternalLinkage,
+        llvm.ConstantStruct.get(struct, values as llvm.Constant[])
+      );
+    } else {
+      const alloc = this.cgen.builder.createAlloca(struct);
+      this.cgen.builder.createStore(llvm.ConstantStruct.get(struct, values as llvm.Constant[]), alloc);
+      return alloc;
+    }
+  }
+
+  private genPropertyAssignment(node: ts.PropertyAssignment): llvm.Value {
+    return this.cgen.genExpression(node.initializer);
+  }
+}

--- a/src/codegen/variable-declaration.ts
+++ b/src/codegen/variable-declaration.ts
@@ -1,8 +1,8 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import LLVMCodeGen from './';
 import { findRealType } from '../common';
+import LLVMCodeGen from './';
 
 export default class CodeGenArray {
   private cgen: LLVMCodeGen;
@@ -116,7 +116,7 @@ export default class CodeGenArray {
     return r;
   }
 
-  private buildStructMaps(struct: llvm.StructType, node: ts.ObjectLiteralExpression) {
+  private buildStructMaps(struct: llvm.StructType, node: ts.ObjectLiteralExpression): Map<string, number> {
     const fields = new Map();
 
     Array.from({ length: struct.numElements }).forEach((_, index) => {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+import llvm from 'llvm-node';
+
+export function genTypesHash(types: llvm.Type[]): string {
+  return digestToHex(types.map(t => t.typeID).join('-'));
+}
+
+export function genStructHash(t: llvm.Type): string {
+  const realType = findRealType(t);
+  if (!realType.isStructTy()) {
+    throw new Error('The generated struct hash must be a struct.');
+  }
+
+  const types = [];
+
+  for (let i = 0; i < realType.numElements; i++) {
+    types.push(realType.getElementType(i));
+  }
+
+  return genTypesHash(types);
+}
+
+export function findRealType(t: llvm.Type): llvm.Type {
+  if (t.isPointerTy()) {
+    return findRealType(t.elementType);
+  }
+
+  return t;
+}
+
+function digestToHex(buf: Buffer | string): string {
+  return crypto
+    .createHash('md5')
+    .update(buf)
+    .digest()
+    .toString('hex');
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,10 +7,12 @@ export enum StructMetaType {
 
 export interface StructMeta {
   metaType: StructMetaType;
-  fields: Map<string, number>;
+  typeHash?: string;
+  struct: llvm.StructType;
 }
 
 export interface SymbolMeta {
   value: llvm.Value;
   deref: number;
+  fields?: Map<string, number>;
 }

--- a/tests/ts/object/return_number.ts
+++ b/tests/ts/object/return_number.ts
@@ -1,0 +1,13 @@
+const Test = {
+  a: 1,
+  d: 12
+};
+
+function main(): number {
+  const Test = {
+    a: 1,
+    c: 10
+  };
+
+  return Test.c;
+}

--- a/tests/ts/object/return_string.ts
+++ b/tests/ts/object/return_string.ts
@@ -1,0 +1,16 @@
+const Test = {
+  a: 1
+};
+
+function main(): number {
+  const Test = {
+    a: 1,
+    c: 'str'
+  };
+
+  if (Test.c === 'str') {
+    return 0;
+  }
+
+  return 1;
+}


### PR DESCRIPTION
## Detail
- Supports literals that define different scopes.
- Support number types.
- Support string types.

## Code generation
### Number
````ts
const Test = {
  a: 1,
  d: 12
};

function main(): number {
  const Test = {
    a: 1,
    c: 10
  };

  return Test.c;
}
````

### LLVM IR
````ll
; ModuleID = 'main'
source_filename = "main"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

%b7d1e4a2ee1c1cae38795edac7ef1d73 = type { i64, i64 }

@0 = global %b7d1e4a2ee1c1cae38795edac7ef1d73 { i64 1, i64 12 }

define i64 @main() {
body:
  %0 = alloca %b7d1e4a2ee1c1cae38795edac7ef1d73
  store %b7d1e4a2ee1c1cae38795edac7ef1d73 { i64 1, i64 10 }, %b7d1e4a2ee1c1cae38795edac7ef1d73* %0
  %1 = getelementptr inbounds %b7d1e4a2ee1c1cae38795edac7ef1d73, %b7d1e4a2ee1c1cae38795edac7ef1d73* %0, i32 0, i32 1
  %2 = load i64, i64* %1
  ret i64 %2
}
````

### String & Number

````ts
const Test = {
  a: 1
};

function main(): number {
  const Test = {
    a: 1,
    c: 'str'
  };

  if (Test.c === 'str') {
    return 0;
  }

  return 1;
}

````
### lLVM IR
````ts
; ModuleID = 'main'
source_filename = "main"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

%"6512bd43d9caa6e02c990b0a82652dca" = type { i64 }
%b40292fd5091e1b9132b8aecc2c9efc2 = type { i64, i8* }

@0 = global %"6512bd43d9caa6e02c990b0a82652dca" { i64 1 }
@string = private unnamed_addr constant [4 x i8] c"str\00", align 1
@string.1 = private unnamed_addr constant [4 x i8] c"str\00", align 1

define i64 @main() {
body:
  %0 = alloca %b40292fd5091e1b9132b8aecc2c9efc2
  store %b40292fd5091e1b9132b8aecc2c9efc2 { i64 1, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string, i32 0, i32 0) }, %b40292fd5091e1b9132b8aecc2c9efc2* %0
  %1 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %0, i32 0, i32 1
  %2 = load i8*, i8** %1
  %3 = call i64 @strcmp(i8* %2, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string.1, i32 0, i32 0))
  %4 = icmp eq i64 %3, 0
  br i1 %4, label %if.then, label %if.else

if.then:                                          ; preds = %body
  ret i64 0

if.else:                                          ; preds = %body
  br label %if.quit

if.quit:                                          ; preds = %if.else
  ret i64 1
}

declare i64 @strcmp(i8*, i8*)
````