### PR TITLE
feat: Support object literals as function parameters.

### DIFF
--- a/src/codegen/binary-expression.ts
+++ b/src/codegen/binary-expression.ts
@@ -196,8 +196,10 @@ export default class CodeGenBinary {
           const arg = this.cgen.genExpression(real.argumentExpression);
           return this.cgen.builder.createInBoundsGEP(ptr, [llvm.ConstantInt.get(this.cgen.context, 0, 64), arg]);
         })();
+      case ts.SyntaxKind.PropertyAccessExpression:
+        return this.cgen.genPropertyAccessExpressionPtr(node as ts.PropertyAccessExpression);
       default:
-        throw new Error('Unsupported grammar');
+        throw new Error(`Unsupported grammar ${node.kind}`);
     }
   }
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -169,10 +169,12 @@ export default class LLVMCodeGen {
 
         // TODO: impl struct
         throw new Error('Unsupported type');
+      case ts.SyntaxKind.TypeLiteral:
+        return this.cgObject.genObjectLiteralType(type as ts.TypeLiteralNode);
       case ts.SyntaxKind.StringKeyword:
         return llvm.Type.getInt8PtrTy(this.context);
       default:
-        throw new Error('Unsupported type');
+        throw new Error(`Unsupported type ${type.kind}`);
     }
   }
 
@@ -346,7 +348,15 @@ export default class LLVMCodeGen {
     return this.cgObject.genObjectElementAccess(node);
   }
 
+  public genPropertyAccessExpressionPtr(node: ts.PropertyAccessExpression): llvm.Value {
+    return this.cgObject.genObjectElementAccessPtr(node);
+  }
+
   public genObjectLiteralExpression(node: ts.ObjectLiteralExpression): llvm.Value {
     return this.cgObject.genObjectLiteralExpression(node);
+  }
+
+  public initObjectInst(varName: string, type: llvm.Type, values: llvm.Constant[]): llvm.Value {
+    return this.cgObject.initObjectInst(varName, type, values);
   }
 }

--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -2,8 +2,8 @@ import Debug from 'debug';
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { genTypesHash } from '../common';
-import { StructMeta, StructMetaType } from '../types';
+import * as common from '../common';
+import { StructMetaType } from '../types';
 import LLVMCodeGen from './';
 
 const debug = Debug('minits:codegen:object');
@@ -18,16 +18,12 @@ export default class GenObject {
   }
 
   public genObjectLiteralExpression(node: ts.ObjectLiteralExpression): llvm.Value {
-    const kinds = [];
+    const varName = (node.parent as ts.VariableDeclaration).name.getText();
     const values: llvm.Value[] = [];
     const types = [];
 
     for (const p of node.properties) {
       if (ts.isPropertyAssignment(p)) {
-        const init = p.initializer;
-
-        kinds.push(init.kind);
-
         const value = this.genPropertyAssignment(p);
         values.push(value);
         types.push(value.type);
@@ -36,7 +32,7 @@ export default class GenObject {
       }
     }
 
-    const typeHash = genTypesHash(types);
+    const typeHash = common.genTypesHash(types);
 
     if (!this.cgen.structTab.get(typeHash)) {
       const structType = llvm.StructType.create(this.cgen.context, typeHash);
@@ -47,33 +43,64 @@ export default class GenObject {
 
     const structMeta = this.cgen.structTab.get(typeHash)!;
 
-    return this.genObjectInst(structMeta.struct, values as llvm.Constant[]);
+    return this.initObjectInst(varName, structMeta.struct, values as llvm.Constant[]);
   }
 
   public genObjectElementAccess(node: ts.PropertyAccessExpression): llvm.Value {
+    const ptr = this.genObjectElementAccessPtr(node);
+    return this.cgen.builder.createLoad(ptr);
+  }
+
+  public genObjectElementAccessPtr(node: ts.PropertyAccessExpression): llvm.Value {
     const { value, fields } = this.cgen.symtab.get(node.expression.getText());
     const field = node.name.getText();
     const index = fields!.get(field)!;
 
-    const ptr = this.cgen.builder.createInBoundsGEP(value, [
+    // const ptr = this.cgen.builder.createLoad(value);
+    return this.cgen.builder.createInBoundsGEP(value, [
       llvm.ConstantInt.get(this.cgen.context, 0, 32, true),
       llvm.ConstantInt.get(this.cgen.context, index, 32, true)
     ]);
-    return this.cgen.builder.createLoad(ptr);
   }
 
-  private genObjectInst(struct: llvm.StructType, values: llvm.Constant[]): llvm.Value {
+  public genObjectLiteralType(type: ts.TypeLiteralNode): llvm.Type {
+    const types: llvm.Type[] = [];
+
+    type.members.forEach(m => types.push(this.genPropertySignature(m as ts.PropertySignature)));
+    const typeHash = common.genTypesHash(types);
+
+    if (!this.cgen.structTab.get(typeHash)) {
+      const structType = llvm.StructType.create(this.cgen.context, typeHash);
+      structType.setBody(types, false);
+
+      this.cgen.structTab.set(typeHash, { metaType: StructMetaType.Class, typeHash, struct: structType });
+    }
+
+    return this.cgen.structTab.get(typeHash)!.struct.getPointerTo();
+  }
+
+  public genPropertySignature(type: ts.PropertySignature): llvm.Type {
+    return this.cgen.genType(type.type!);
+  }
+
+  public initObjectInst(varName: string, type: llvm.Type, values: llvm.Constant[]): llvm.Value {
+    const structType = common.findRealType(type);
+    if (!structType.isStructTy()) {
+      throw new Error('The type must be a struct.');
+    }
+
+    // TODO: If values is empty, assign an initial value.
     if (this.cgen.symtab.isGlobal()) {
       return new llvm.GlobalVariable(
         this.cgen.module,
-        struct,
+        structType,
         false,
         llvm.LinkageTypes.ExternalLinkage,
-        llvm.ConstantStruct.get(struct, values as llvm.Constant[])
+        llvm.ConstantStruct.get(structType, values as llvm.Constant[])
       );
     } else {
-      const alloc = this.cgen.builder.createAlloca(struct);
-      this.cgen.builder.createStore(llvm.ConstantStruct.get(struct, values as llvm.Constant[]), alloc);
+      const alloc = this.cgen.builder.createAlloca(structType, undefined, varName);
+      this.cgen.builder.createStore(llvm.ConstantStruct.get(structType, values as llvm.Constant[]), alloc);
       return alloc;
     }
   }

--- a/src/codegen/variable-declaration.ts
+++ b/src/codegen/variable-declaration.ts
@@ -1,7 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { findRealType } from '../common';
+import { findRealType, buildStructMaps } from '../common';
 import LLVMCodeGen from './';
 
 export default class CodeGenArray {
@@ -33,8 +33,7 @@ export default class CodeGenArray {
 
     const realType = findRealType(type);
     if (realType.isStructTy()) {
-      const fields = this.buildStructMaps(realType, node.initializer! as ts.ObjectLiteralExpression);
-
+      const fields = buildStructMaps(realType, node.initializer! as ts.ObjectLiteralExpression);
       this.cgen.symtab.set(name, { value: initializer, deref: 0, fields });
       return initializer;
     }
@@ -114,16 +113,5 @@ export default class CodeGenArray {
     );
     this.cgen.symtab.set(name, { value: r, deref: 0 });
     return r;
-  }
-
-  private buildStructMaps(struct: llvm.StructType, node: ts.ObjectLiteralExpression): Map<string, number> {
-    const fields = new Map();
-
-    Array.from({ length: struct.numElements }).forEach((_, index) => {
-      const field = (node.properties[index].name as ts.Identifier).getText();
-      fields.set(field, index);
-    });
-
-    return fields;
   }
 }

--- a/tests/ts/object/call_mut.ts
+++ b/tests/ts/object/call_mut.ts
@@ -1,0 +1,18 @@
+function mut(obj: { num: number; str: string }): void {
+  obj.num = 100;
+  obj.str = 'hello world';
+  return;
+}
+
+function main(): number {
+  let testObj = {
+    num: 10,
+    str: '123'
+  };
+
+  mut(testObj);
+  if (testObj.str !== 'hello world') {
+    return 1;
+  }
+  return testObj.num;
+}


### PR DESCRIPTION
## Describe
Support object literals as function parameters

NOTE: object literals are always passed as a pointer.

## Source code
````ts
function mut(obj: { num: number; str: string }): void {
  obj.num = 100;
  obj.str = 'hello world';
  return;
}

function main(): number {
  let testObj = {
    num: 10,
    str: '123'
  };

  mut(testObj);
  if (testObj.str !== 'hello world') {
    return 1;
  }
  return testObj.num;
}

````


## LLVM IR
````ll
; ModuleID = 'main'
source_filename = "main"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

%b40292fd5091e1b9132b8aecc2c9efc2 = type { i64, i8* }

@string = private unnamed_addr constant [12 x i8] c"hello world\00", align 1
@string.1 = private unnamed_addr constant [4 x i8] c"123\00", align 1
@string.2 = private unnamed_addr constant [12 x i8] c"hello world\00", align 1

define void @mut(%b40292fd5091e1b9132b8aecc2c9efc2* %obj) {
body:
  %0 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %obj, i32 0, i32 0
  store i64 100, i64* %0
  %1 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %obj, i32 0, i32 1
  store i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string, i32 0, i32 0), i8** %1
  ret void
}

define i64 @main() {
body:
  %testObj = alloca %b40292fd5091e1b9132b8aecc2c9efc2
  store %b40292fd5091e1b9132b8aecc2c9efc2 { i64 10, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string.1, i32 0, i32 0) }, %b40292fd5091e1b9132b8aecc2c9efc2* %testObj
  call void @mut(%b40292fd5091e1b9132b8aecc2c9efc2* %testObj)
  %0 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %testObj, i32 0, i32 1
  %1 = load i8*, i8** %0
  %2 = call i64 @strcmp(i8* %1, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string.2, i32 0, i32 0))
  %3 = icmp ne i64 %2, 0
  br i1 %3, label %if.then, label %if.else

if.then:                                          ; preds = %body
  ret i64 1

if.else:                                          ; preds = %body
  br label %if.quit

if.quit:                                          ; preds = %if.else
  %4 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %testObj, i32 0, i32 0
  %5 = load i64, i64* %4
  ret i64 %5
}

declare i64 @strcmp(i8*, i8*)
````