### PR TITLE
feat: Supports object literals as function return values.

### DIFF
--- a/src/codegen/function-declaration.ts
+++ b/src/codegen/function-declaration.ts
@@ -31,6 +31,13 @@ export default class CodeGenFuncDecl {
         });
       }
     });
+
+    if (node.type && common.findRealType(funcReturnType).isStructTy()) {
+      const typeLiteral = node.type! as ts.TypeLiteralNode;
+      const fields = common.buildStructMaps(funcReturnType as llvm.StructType, typeLiteral);
+
+      this.cgen.symtab.set(func.name, { inner: func, deref: 0, fields });
+    }
     return func;
   }
 

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -3,6 +3,8 @@ import llvm from 'llvm-node';
 class Value {
   public inner: llvm.Value;
   public deref: number;
+  // If the type of type is a struct, fields are the fields contained in the struct
+  // If the type of  is a function and the return value is an object, fields is the field of the object.
   public fields?: Map<string, number>;
 
   constructor(inner: llvm.Value, deref: number, fields?: Map<string, number>) {

--- a/tests/ts/object/return_mut.ts
+++ b/tests/ts/object/return_mut.ts
@@ -1,0 +1,23 @@
+function mut(obj: { num: number; str: string }): { num: number; str: string } {
+  obj.num = 100;
+  obj.str = 'hello world';
+  return obj;
+}
+
+function main(): number {
+  let testObj = {
+    num: 10,
+    str: '123'
+  };
+
+  let mutObj = mut(testObj);
+  if (mutObj.str !== 'hello world') {
+    return 1;
+  }
+
+  if (mutObj.num !== 100) {
+    return 1;
+  }
+
+  return mutObj.num;
+}


### PR DESCRIPTION
## Source code
````ts
function mut(obj: { num: number; str: string }): { num: number; str: string } {
  obj.num = 100;
  obj.str = 'hello world';
  return obj;
}

function main(): number {
  let testObj = {
    num: 10,
    str: '123'
  };

  let mutObj = mut(testObj);
  if (mutObj.str !== 'hello world') {
    return 1;
  }

  if (mutObj.num !== 100) {
    return 1;
  }

  return mutObj.num;
}
````

## LLVM IR
````ll
source_filename = "main"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

%b40292fd5091e1b9132b8aecc2c9efc2 = type { i64, i8* }

@mut.unnamed = private unnamed_addr constant [12 x i8] c"hello world\00", align 1
@main.testObj = private unnamed_addr constant [4 x i8] c"123\00", align 1
@main.unnamed = private unnamed_addr constant [12 x i8] c"hello world\00", align 1

define %b40292fd5091e1b9132b8aecc2c9efc2* @mut(%b40292fd5091e1b9132b8aecc2c9efc2* %obj) {
body:
  %0 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %obj, i32 0, i32 0
  store i64 100, i64* %0
  %1 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %obj, i32 0, i32 1
  store i8* getelementptr inbounds ([12 x i8], [12 x i8]* @mut.unnamed, i32 0, i32 0), i8** %1
  ret %b40292fd5091e1b9132b8aecc2c9efc2* %obj
}

define i64 @main() {
body:
  %testObj = alloca %b40292fd5091e1b9132b8aecc2c9efc2
  store %b40292fd5091e1b9132b8aecc2c9efc2 { i64 10, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @main.testObj, i32 0, i32 0) }, %b40292fd5091e1b9132b8aecc2c9efc2* %testObj
  %0 = call %b40292fd5091e1b9132b8aecc2c9efc2* @mut(%b40292fd5091e1b9132b8aecc2c9efc2* %testObj)
  %1 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %0, i32 0, i32 1
  %2 = load i8*, i8** %1
  %3 = call i64 @strcmp(i8* %2, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @main.unnamed, i32 0, i32 0))
  %4 = icmp ne i64 %3, 0
  br i1 %4, label %if.then, label %if.else

if.then:                                          ; preds = %body
  ret i64 1

if.else:                                          ; preds = %body
  br label %if.quit

if.quit:                                          ; preds = %if.else
  %5 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %0, i32 0, i32 0
  %6 = load i64, i64* %5
  %7 = icmp ne i64 %6, 100
  br i1 %7, label %if.then1, label %if.else2

if.then1:                                         ; preds = %if.quit
  ret i64 1

if.else2:                                         ; preds = %if.quit
  br label %if.quit3

if.quit3:                                         ; preds = %if.else2
  %8 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %0, i32 0, i32 0
  %9 = load i64, i64* %8
  ret i64 %9
}

declare i64 @strcmp(i8*, i8*)
````