### PR TITLE
Implement global array of string

### DIFF
--- a/src/codegen/array-literal-expression.ts
+++ b/src/codegen/array-literal-expression.ts
@@ -66,12 +66,14 @@ export default class CodeGenArray {
 
   public genArrayLiteralGlobal(node: ts.ArrayLiteralExpression): llvm.GlobalVariable {
     const arrayType = this.cgen.cgArray.genArrayType(node);
-    const arrayData = llvm.ConstantArray.get(
-      arrayType,
-      node.elements.map(item => {
-        return this.cgen.genExpression(item) as llvm.Constant;
-      })
-    );
+    const arrayData = this.cgen.withName(undefined, () => {
+      return llvm.ConstantArray.get(
+        arrayType,
+        node.elements.map(item => {
+          return this.cgen.genExpression(item) as llvm.Constant;
+        })
+      );
+    });
     const r = new llvm.GlobalVariable(
       this.cgen.module,
       arrayType,

--- a/src/codegen/numeric-expression.ts
+++ b/src/codegen/numeric-expression.ts
@@ -11,6 +11,14 @@ export default class CodeGenNumeric {
   }
 
   public genNumeric(node: ts.NumericLiteral): llvm.ConstantInt {
+    if (this.cgen.currentFunction === undefined) {
+      return this.genNumericGlobal(node);
+    } else {
+      return this.genNumericLocale(node);
+    }
+  }
+
+  public genNumericLocale(node: ts.NumericLiteral): llvm.ConstantInt {
     const text = node.getText();
     const bits = (() => {
       if (text.startsWith('0x')) {
@@ -22,17 +30,7 @@ export default class CodeGenNumeric {
     return llvm.ConstantInt.get(this.cgen.context, parseInt(text, bits), 64);
   }
 
-  public genNumericGlobal(node: ts.NumericLiteral): llvm.GlobalVariable {
-    const initializer = this.cgen.genNumeric(node);
-    const type = initializer.type;
-    const r = new llvm.GlobalVariable(
-      this.cgen.module,
-      type,
-      false,
-      llvm.LinkageTypes.ExternalLinkage,
-      initializer,
-      this.cgen.symtab.name() + this.cgen.readName()
-    );
-    return r;
+  public genNumericGlobal(node: ts.NumericLiteral): llvm.ConstantInt {
+    return this.genNumericLocale(node);
   }
 }

--- a/src/codegen/variable-declaration.ts
+++ b/src/codegen/variable-declaration.ts
@@ -66,13 +66,29 @@ export default class CodeGenArray {
   }
 
   public genVariableDeclarationGlobalNumeric(node: ts.NumericLiteral): llvm.GlobalVariable {
-    const r = this.cgen.cgNumeric.genNumericGlobal(node);
+    const a = this.cgen.cgNumeric.genNumericGlobal(node);
+    const r = new llvm.GlobalVariable(
+      this.cgen.module,
+      a.type,
+      false,
+      llvm.LinkageTypes.ExternalLinkage,
+      a,
+      this.cgen.symtab.name() + this.cgen.readName()
+    );
     this.cgen.symtab.set(this.cgen.readName(), { inner: r, deref: 1 });
     return r;
   }
 
   public genVariableDeclarationGlobalStringLiteral(node: ts.StringLiteral): llvm.GlobalVariable {
-    const v = this.cgen.cgString.genStringLiteralGlobal(node);
+    const a = this.cgen.cgString.genStringLiteralGlobal(node);
+    const v = new llvm.GlobalVariable(
+      this.cgen.module,
+      a.type,
+      false,
+      llvm.LinkageTypes.ExternalLinkage,
+      a as llvm.Constant,
+      this.cgen.symtab.name() + this.cgen.readName()
+    );
     this.cgen.symtab.set(this.cgen.readName(), { inner: v, deref: 1 });
     return v;
   }

--- a/tests/ts/array/array_of_string.ts
+++ b/tests/ts/array/array_of_string.ts
@@ -1,0 +1,12 @@
+let globalarr: string[] = ["10", "20"];
+
+function main(): number {
+    let localarr: string[] = ["10", "20"];
+    if (globalarr[0] !== localarr[0]) {
+        return 1;
+    }
+    if (globalarr[1] !== localarr[1]) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
- Fix a bug for global array of string, the error codes are [here](https://github.com/cryptape/minits/pull/35/files#diff-ef26aade9a45fffc3cc94cc4aee5e5a8R27)

**TS**

```ts
let globalarr: string[] = ["10", "20"];
```

**IR**

```
@str = global [3 x i8] c"10\00"
@str.1 = global [3 x i8] c"20\00"
@globalarr = global [2 x i8*] [i8* getelementptr inbounds ([3 x i8], [3 x i8]* @str, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @str.1, i32 0, i32 0)]
```