### PR TITLE
Function can ignore return statement

### DIFF
--- a/src/codegen/function-declaration.ts
+++ b/src/codegen/function-declaration.ts
@@ -12,7 +12,13 @@ export default class CodeGenFuncDecl {
   }
 
   public genFunctionDeclaration(node: ts.FunctionDeclaration): llvm.Function {
-    const funcReturnType = this.cgen.genType(node.type!);
+    const funcReturnType = (() => {
+      if (node.type) {
+        return this.cgen.genType(node.type);
+      } else {
+        return llvm.Type.getVoidTy(this.cgen.context);
+      }
+    })();
     const funcArgsType = node.parameters.map(item => {
       return this.cgen.genType(item.type!);
     });
@@ -28,6 +34,9 @@ export default class CodeGenFuncDecl {
         this.cgen.builder.setInsertionPoint(body);
         this.cgen.withFunction(func, () => {
           this.cgen.genBlock(node.body!);
+          if (!body.getTerminator()) {
+            this.cgen.builder.createRetVoid();
+          }
         });
       }
     });

--- a/src/tests/function.spec.ts
+++ b/src/tests/function.spec.ts
@@ -43,3 +43,20 @@ test('test function return 1', async t => {
 
   t.pass();
 });
+
+test('test function ignore return', async t => {
+  await runCode(
+    `
+    function echo() {
+      console.log("Hello World!");
+    }
+
+    function main(): number {
+      echo();
+      return 0;
+    }
+    `
+  );
+
+  t.pass();
+});


### PR DESCRIPTION
When a function returns void, the type hint and return statement can both ignored.

**ts**

```ts
function echo() {
}
```
**IR**

```
define void @echo() {
body:
  ret void
}
```