### PR TITLE
refactor(symtab): Rewrite the values of the symbol table to support multiple types.

### DIFF
--- a/src/codegen/array-literal-expression.ts
+++ b/src/codegen/array-literal-expression.ts
@@ -1,7 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { Value } from '../symtab';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenArray {
@@ -28,10 +28,11 @@ export default class CodeGenArray {
       }
       // Identifier
       if (node.elements[0].kind === ts.SyntaxKind.Identifier) {
-        const symbol = this.cgen.symtab.get(node.elements[0].getText())! as Value;
+        const symbol = this.cgen.symtab.get(node.elements[0].getText())! as symtab.LLVMValue;
         if (symbol.inner.type.isPointerTy()) {
           return (symbol.inner.type as llvm.PointerType).elementType;
         }
+
         return symbol.inner.type;
       }
 

--- a/src/codegen/binary-expression.ts
+++ b/src/codegen/binary-expression.ts
@@ -1,7 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { Value } from '../symtab';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 const CompoundAssignmentOperator = [
@@ -189,7 +189,7 @@ export default class CodeGenBinary {
   public genSymbolPtr(node: ts.Expression): llvm.Value {
     switch (node.kind) {
       case ts.SyntaxKind.Identifier:
-        return (this.cgen.symtab.get((node as ts.Identifier).getText()) as Value).inner;
+        return (this.cgen.symtab.get((node as ts.Identifier).getText()) as symtab.LLVMValue).inner;
       case ts.SyntaxKind.ElementAccessExpression:
         return (() => {
           const real = node as ts.ElementAccessExpression;

--- a/src/codegen/enum-declaration.ts
+++ b/src/codegen/enum-declaration.ts
@@ -1,6 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenStruct {
@@ -17,16 +18,13 @@ export default class CodeGenStruct {
         const v = this.cgen.checker.getConstantValue(item);
         switch (typeof v) {
           case 'string':
-            this.cgen.symtab.set(name, {
-              deref: 0,
-              inner: this.cgen.cgString.genStringLiteral(item.initializer! as ts.StringLiteral)
-            });
+            this.cgen.symtab.set(
+              name,
+              new symtab.LLVMValue(this.cgen.cgString.genStringLiteral(item.initializer! as ts.StringLiteral), 0)
+            );
             break;
           case 'number':
-            this.cgen.symtab.set(name, {
-              deref: 0,
-              inner: llvm.ConstantInt.get(this.cgen.context, v, 64)
-            });
+            this.cgen.symtab.set(name, new symtab.LLVMValue(llvm.ConstantInt.get(this.cgen.context, v, 64), 0));
             break;
         }
       });

--- a/src/codegen/for-of-statement.ts
+++ b/src/codegen/for-of-statement.ts
@@ -1,6 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenForOf {
@@ -17,7 +18,7 @@ export default class CodeGenForOf {
       const type = initializer.type;
       const alloca = this.cgen.builder.createAlloca(type, undefined, name);
       this.cgen.builder.createStore(initializer, alloca);
-      this.cgen.symtab.set(name, { inner: alloca, deref: 1 });
+      this.cgen.symtab.set(name, new symtab.LLVMValue(alloca, 1));
       return alloca;
     })();
     const a = this.cgen.genExpression(node.expression) as llvm.AllocaInst;
@@ -25,7 +26,7 @@ export default class CodeGenForOf {
       const type = (a.type.elementType as llvm.ArrayType).elementType;
       const name = (node.initializer! as ts.VariableDeclarationList).declarations!.map(item => item.getText())[0];
       const alloca = this.cgen.builder.createAlloca(type, undefined, name);
-      this.cgen.symtab.set(name, { inner: alloca, deref: 1 });
+      this.cgen.symtab.set(name, new symtab.LLVMValue(alloca, 1));
       return alloca;
     })();
     const loopCond = llvm.BasicBlock.create(this.cgen.context, 'loop.cond', this.cgen.currentFunction);

--- a/src/codegen/function-declaration.ts
+++ b/src/codegen/function-declaration.ts
@@ -2,7 +2,7 @@ import llvm from 'llvm-node';
 import ts from 'typescript';
 
 import * as common from '../common';
-import { Value } from '../symtab';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenFuncDecl {
@@ -31,7 +31,7 @@ export default class CodeGenFuncDecl {
       func.addFnAttr(llvm.Attribute.AttrKind.NoInline);
       func.addFnAttr(llvm.Attribute.AttrKind.OptimizeNone);
     }
-    this.cgen.symtab.set(name, new Value(func, 0));
+    this.cgen.symtab.set(name, new symtab.LLVMValue(func, 0));
 
     this.cgen.symtab.with(undefined, () => {
       this.initArguments(func, node);
@@ -51,7 +51,7 @@ export default class CodeGenFuncDecl {
       const typeLiteral = node.type! as ts.TypeLiteralNode;
       const fields = common.buildStructMaps(funcReturnType as llvm.StructType, typeLiteral);
 
-      this.cgen.symtab.set(func.name, { inner: func, deref: 0, fields });
+      this.cgen.symtab.set(name, new symtab.LLVMValue(func, 0, fields));
     }
     return func;
   }
@@ -67,10 +67,10 @@ export default class CodeGenFuncDecl {
             node.parameters[item.argumentNumber].type! as ts.TypeLiteralNode
           );
 
-          this.cgen.symtab.set(item.name, { inner: item, deref: 0, fields });
+          this.cgen.symtab.set(item.name, new symtab.LLVMValue(item, 0, fields));
           break;
         default:
-          this.cgen.symtab.set(item.name, { inner: item, deref: 0 });
+          this.cgen.symtab.set(item.name, new symtab.LLVMValue(item, 0));
       }
     });
   }

--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -3,7 +3,7 @@ import llvm from 'llvm-node';
 import ts from 'typescript';
 
 import * as common from '../common';
-import { Value } from '../symtab';
+import * as symtab from '../symtab';
 import { StructMetaType } from '../types';
 import LLVMCodeGen from './';
 
@@ -53,7 +53,7 @@ export default class GenObject {
   }
 
   public genObjectElementAccessPtr(node: ts.PropertyAccessExpression): llvm.Value {
-    const { inner, fields } = this.cgen.symtab.get(node.expression.getText()) as Value;
+    const { inner, fields } = this.cgen.symtab.get(node.expression.getText()) as symtab.LLVMValue;
     const field = node.name.getText();
     const index = fields!.get(field)!;
 

--- a/src/codegen/postfix-unary-expression.ts
+++ b/src/codegen/postfix-unary-expression.ts
@@ -1,7 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { Value } from '../symtab';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenPostfixUnary {
@@ -20,7 +20,7 @@ export default class CodeGenPostfixUnary {
         return (() => {
           const one = llvm.ConstantInt.get(this.cgen.context, 1, 64);
           const r = this.cgen.builder.createAdd(lhs, one);
-          const ptr = (this.cgen.symtab.get(e.getText())! as Value).inner;
+          const ptr = (this.cgen.symtab.get(e.getText())! as symtab.LLVMValue).inner;
           this.cgen.builder.createStore(r, ptr);
           return lhs;
         })();
@@ -29,7 +29,7 @@ export default class CodeGenPostfixUnary {
         return (() => {
           const one = llvm.ConstantInt.get(this.cgen.context, 1, 64);
           const r = this.cgen.builder.createSub(lhs, one);
-          const ptr = (this.cgen.symtab.get(e.getText()) as Value).inner;
+          const ptr = (this.cgen.symtab.get(e.getText()) as symtab.LLVMValue).inner;
           this.cgen.builder.createStore(r, ptr);
           return lhs;
         })();

--- a/src/codegen/property-access-expression.ts
+++ b/src/codegen/property-access-expression.ts
@@ -1,7 +1,7 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
-import { Scope, Value } from '../symtab';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenPropertyAccessExpression {
@@ -19,8 +19,9 @@ export default class CodeGenPropertyAccessExpression {
         return this.cgen.symtab.get((node.expression as ts.Identifier).getText());
       }
     })();
-    if (parent instanceof Scope) {
-      const son = parent.data.get(node.name.getText())! as Value;
+
+    if (symtab.isScope(parent)) {
+      const son = parent.inner.get(node.name.getText())! as symtab.LLVMValue;
       let r = son.inner;
       for (let i = 0; i < son.deref; i++) {
         r = this.cgen.builder.createLoad(r);
@@ -30,8 +31,8 @@ export default class CodeGenPropertyAccessExpression {
     return this.cgen.cgObject.genObjectElementAccess(node);
   }
 
-  private fromScope(node: ts.PropertyAccessExpression): Scope | Value {
-    const parent = this.cgen.symtab.get((node.expression as ts.Identifier).getText()) as Scope;
-    return parent.data.get(node.name.getText())!;
+  private fromScope(node: ts.PropertyAccessExpression): symtab.Value {
+    const parent = this.cgen.symtab.get((node.expression as ts.Identifier).getText()) as symtab.Scope;
+    return parent.inner.get(node.name.getText())!;
   }
 }

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -30,7 +30,7 @@ class Scope implements Value {
   }
 }
 
-function isLLVM(value: Value): value is LLVMValue {
+function isLLVMValue(value: Value): value is LLVMValue {
   return value instanceof LLVMValue ? true : false;
 }
 
@@ -105,4 +105,4 @@ class Symtab {
   }
 }
 
-export { Value, Scope, Symtab, LLVMValue, isLLVM, isScope };
+export { Value, Scope, Symtab, LLVMValue, isLLVMValue, isScope };

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -1,8 +1,7 @@
 import llvm from 'llvm-node';
-import ts from 'typescript';
 
 interface Value {
-  inner: any;
+  inner: llvm.Value | Map<string, Value>;
 }
 
 class LLVMValue implements Value {
@@ -16,14 +15,6 @@ class LLVMValue implements Value {
     this.inner = inner;
     this.deref = deref;
     this.fields = fields;
-  }
-}
-
-class TSNode implements Value {
-  public readonly inner: ts.Node;
-
-  constructor(inner: ts.Node) {
-    this.inner = inner;
   }
 }
 
@@ -41,10 +32,6 @@ class Scope implements Value {
 
 function isLLVM(value: Value): value is LLVMValue {
   return value instanceof LLVMValue ? true : false;
-}
-
-function isTSNode(value: Value): value is TSNode {
-  return value instanceof TSNode ? true : false;
 }
 
 function isScope(value: Value): value is Scope {
@@ -118,4 +105,4 @@ class Symtab {
   }
 }
 
-export { Value, Scope, Symtab, TSNode, LLVMValue, isLLVM, isTSNode, isScope };
+export { Value, Scope, Symtab, LLVMValue, isLLVM, isScope };

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -1,11 +1,16 @@
 import llvm from 'llvm-node';
+import ts from 'typescript';
 
-class Value {
-  public inner: llvm.Value;
-  public deref: number;
+interface Value {
+  inner: any;
+}
+
+class LLVMValue implements Value {
+  public readonly inner: llvm.Value;
+  public readonly deref: number;
   // If the type of type is a struct, fields are the fields contained in the struct
   // If the type of  is a function and the return value is an object, fields is the field of the object.
-  public fields?: Map<string, number>;
+  public readonly fields?: Map<string, number>;
 
   constructor(inner: llvm.Value, deref: number, fields?: Map<string, number>) {
     this.inner = inner;
@@ -14,16 +19,36 @@ class Value {
   }
 }
 
-class Scope {
-  public name: string | undefined;
-  public data: Map<string, Value | Scope>;
-  public parent: Scope | undefined;
+class TSNode implements Value {
+  public readonly inner: ts.Node;
 
-  constructor(name: string | undefined, parent?: Scope | undefined) {
+  constructor(inner: ts.Node) {
+    this.inner = inner;
+  }
+}
+
+class Scope implements Value {
+  public name?: string;
+  public inner: Map<string, Value>;
+  public parent?: Scope;
+
+  constructor(name?: string, parent?: Scope) {
     this.name = name;
-    this.data = new Map();
+    this.inner = new Map();
     this.parent = parent;
   }
+}
+
+function isLLVM(value: Value): value is LLVMValue {
+  return value instanceof LLVMValue ? true : false;
+}
+
+function isTSNode(value: Value): value is TSNode {
+  return value instanceof TSNode ? true : false;
+}
+
+function isScope(value: Value): value is Scope {
+  return value instanceof Scope ? true : false;
 }
 
 class Symtab {
@@ -36,7 +61,7 @@ class Symtab {
   public into(name: string | undefined): Scope {
     const n = new Scope(name, this.data);
     if (name) {
-      this.data.data.set(name, n);
+      this.data.inner.set(name, n);
     }
     this.data = n;
     return n;
@@ -47,13 +72,14 @@ class Symtab {
   }
 
   public name(): string {
-    if (this.data.parent === undefined) {
+    if (!this.data.parent) {
       return '';
     }
+
     const list = [];
     let n: Scope | undefined = this.data;
     for (;;) {
-      if (n === undefined) {
+      if (!n) {
         break;
       }
       if (n.name) {
@@ -70,15 +96,15 @@ class Symtab {
     this.exit();
   }
 
-  public set(key: string, value: Value | Scope): void {
-    this.data.data.set(key, value);
+  public set(key: string, value: Value): void {
+    this.data.inner.set(key, value);
   }
 
-  public get(key: string): Value | Scope {
-    let n = this.data;
+  public get(key: string): Value {
+    let n: Scope = this.data;
 
     while (true) {
-      const v = n.data.get(key);
+      const v = n.inner.get(key);
       if (v) {
         return v;
       }
@@ -92,4 +118,4 @@ class Symtab {
   }
 }
 
-export { Value, Scope, Symtab };
+export { Value, Scope, Symtab, TSNode, LLVMValue, isLLVM, isTSNode, isScope };


### PR DESCRIPTION
## Describe

Symbol table values now support the following two types:
1. **LLVMValue**: An abstraction of the `LLVM` type.
3. **Scope**: `Scope` of a function or block or global.