### PR TITLE
feat: Scan all functions for dependencies before code generation.

### DIFF
--- a/src/codegen/main-declaration.ts
+++ b/src/codegen/main-declaration.ts
@@ -1,0 +1,26 @@
+import ts from 'typescript';
+
+import { NodeDepends } from '../types';
+import LLVMCodeGen from './';
+
+export default class MainDeclaration {
+  private cgen: LLVMCodeGen;
+
+  constructor(cgen: LLVMCodeGen) {
+    this.cgen = cgen;
+  }
+
+  public genMainFunction(): void {
+    this.genDepends(this.cgen.nodeDep);
+  }
+
+  private genDepends(deps: NodeDepends): void {
+    const { self, depends } = deps;
+
+    depends.forEach(dep => {
+      this.genDepends(dep);
+    });
+
+    this.cgen.genFunctionDeclaration(self as ts.FunctionDeclaration);
+  }
+}

--- a/src/prepare/depends.ts
+++ b/src/prepare/depends.ts
@@ -1,0 +1,88 @@
+import ts from 'typescript';
+
+import { StdFunc } from '../stdlib';
+import { NodeDepends } from '../types';
+
+export default class Depends {
+  private readonly program: ts.Program;
+  private readonly checker: ts.TypeChecker;
+
+  constructor(program: ts.Program) {
+    this.program = program;
+    this.checker = program.getTypeChecker();
+  }
+
+  public genDepends(fileName: string): NodeDepends {
+    let main: ts.FunctionDeclaration | null = null;
+
+    this.program.getSourceFile(fileName)!.forEachChild(node => {
+      if (ts.isFunctionDeclaration(node)) {
+        if (!node.name) {
+          return;
+        }
+
+        if (node.name!.getText() !== 'main') {
+          return;
+        }
+
+        if (main) {
+          throw new Error('Fuck! You want to define two main functions?');
+        }
+        main = node;
+      }
+    });
+
+    if (!main) {
+      throw new Error('The main function is required.');
+    }
+
+    return this.scanFunc(main!)!;
+  }
+
+  private scanFunc(node: ts.FunctionDeclaration): NodeDepends | null {
+    const dep: NodeDepends = { self: node, depends: [] };
+    if (!node.body) {
+      return dep;
+    }
+
+    dep.depends = this.findDepends(node, dep);
+
+    return dep;
+  }
+
+  private scanCallExpression(node: ts.CallExpression): NodeDepends | null {
+    // is stdlib?
+    if (Object.values(StdFunc).includes(node.expression.getText())) {
+      return null;
+    }
+
+    const funcDecl = this.checker.getResolvedSignature(node)!.getDeclaration() as ts.FunctionDeclaration;
+    return this.scanFunc(funcDecl);
+  }
+
+  private findDepends(node: ts.Node, currentDep: NodeDepends): NodeDepends[] {
+    let deps: NodeDepends[] = [];
+
+    node.forEachChild(subNode => {
+      switch (subNode.kind) {
+        case ts.SyntaxKind.CallExpression:
+          // Determines whether a function recursive call exists.
+          const funcDecl = this.checker.getResolvedSignature(subNode as ts.CallExpression)!.getDeclaration() as ts.Node;
+          if (funcDecl === currentDep.self) {
+            return;
+          }
+
+          const dep = this.scanCallExpression(subNode as ts.CallExpression);
+          if (dep) {
+            deps.push(dep);
+          }
+          break;
+        default:
+          deps = deps.concat(this.findDepends(subNode, currentDep));
+          break;
+      }
+    });
+
+    return deps;
+  }
+}

--- a/src/prepare/index.ts
+++ b/src/prepare/index.ts
@@ -1,3 +1,4 @@
+import PrepareDepends from './depends';
 import PrepareImpot from './import';
 
-export { PrepareImpot };
+export { PrepareImpot, PrepareDepends };

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -2,7 +2,15 @@ import llvm from 'llvm-node';
 
 import LLVMCodeGen from '../codegen';
 
-export default class Stdlib {
+export enum StdFunc {
+  consoleLog = 'console.log',
+  printf = 'printf',
+  strcmp = 'strcmp',
+  strlen = 'strlen',
+  syscall = 'syscall'
+}
+
+export class Stdlib {
   private cgen: LLVMCodeGen;
 
   constructor(cgen: LLVMCodeGen) {

--- a/src/tests/prepare.spec.ts
+++ b/src/tests/prepare.spec.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import shell from 'shelljs';
 
 import { PrepareImpot } from '../prepare';
+import { runCode } from './util';
 
 const main = `
 import a from './import-a'
@@ -50,4 +51,29 @@ test('test prepare import', async t => {
   t.assert(set.has(aFile));
   t.assert(set.has(bFile));
   t.assert(set.has(cFile));
+});
+
+test('test prepare depends', async t => {
+  runCode(`
+    function main(): number {
+      funcA();
+      return 0;
+    }
+
+    function funcD() {
+      funcC();
+    }
+
+    function funcC() {}
+
+    function funcB() {
+      funcD();
+    }
+
+    function funcA() {
+      funcD();
+    }
+  `);
+
+  t.pass();
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import llvm from 'llvm-node';
+import ts from 'typescript';
 
 export enum StructMetaType {
   Class,
@@ -9,4 +10,9 @@ export interface StructMeta {
   metaType: StructMetaType;
   typeHash?: string;
   struct: llvm.StructType;
+}
+
+export interface NodeDepends {
+  self: ts.Node;
+  depends: NodeDepends[];
 }


### PR DESCRIPTION
## Describe

Now, with the `main` function as the entry point before performing code generation, the `src/prepare/depends` will scan all function call dependencies to ensure that function declaration is generated in the correct order.

Suppose we have the following code:
````ts
function main(): number {
  funcA();
  return 0;
}

function funcD() {
  funcC();
}

function funcC() {}

function funcB() {
  funcD();
}

function funcA() {
  funcD();
}
````
Their dependencies:
````yaml
main:
  depends:
    - funcA:
      depends:
        - funcD:
          depends:
            - funcC:
              depends: null
````

`CodeGen` generates function declarations from the bottom up based on dependencies.

LLVM IR
````ll
; ModuleID = 'main'
source_filename = "examples/foo.ts"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

define void @funcC() {
body:
  ret void
}

define void @funcD() {
body:
  call void @funcC()
  ret void
}

define void @funcA() {
body:
  call void @funcD()
  ret void
}

; Function Attrs: noinline optnone
define i64 @main() #0 {
body:
  call void @funcA()
  ret i64 0
}

attributes #0 = { noinline optnone }
````