### PR TITLE
feat: Supports passing duck type objects on function calls.

### DIFF
--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -1,6 +1,8 @@
 import llvm from 'llvm-node';
 import ts from 'typescript';
 
+import * as common from '../common';
+import * as symtab from '../symtab';
 import LLVMCodeGen from './';
 
 export default class CodeGenFuncDecl {
@@ -12,23 +14,30 @@ export default class CodeGenFuncDecl {
 
   public genCallExpression(node: ts.CallExpression): llvm.Value {
     const name = node.expression.getText();
-    const args = node.arguments.map(item => {
-      return this.cgen.genExpression(item);
-    });
+
     switch (name) {
       case 'console.log':
-        return this.cgen.stdlib.printf(args);
+        return this.cgen.stdlib.printf(this.genArguments(node.arguments));
       case 'printf':
-        return this.cgen.stdlib.printf(args);
+        return this.cgen.stdlib.printf(this.genArguments(node.arguments));
       case 'strcmp':
-        return this.cgen.stdlib.strcmp(args);
+        return this.cgen.stdlib.strcmp(this.genArguments(node.arguments));
       case 'strlen':
-        return this.cgen.stdlib.strlen(args);
+        return this.cgen.stdlib.strlen(this.genArguments(node.arguments));
       case 'syscall':
-        return this.cgen.stdlib.syscall(args);
+        return this.cgen.stdlib.syscall(this.genArguments(node.arguments));
       default:
-        const func = this.cgen.genExpression(node.expression);
-        return this.cgen.builder.createCall(func, args);
+        const hashName = common.genFunctionHashWithCall(this.cgen.checker, node);
+        const value = this.cgen.symtab.get(hashName);
+        if (symtab.isLLVMValue(value)) {
+          return this.cgen.builder.createCall(value.inner, this.genArguments(node.arguments));
+        }
+
+        throw new Error('The type retrieved from the symbol table must be LLVM value.');
     }
+  }
+
+  private genArguments(args: ts.NodeArray<ts.Expression>): llvm.Value[] {
+    return args.map(item => this.cgen.genExpression(item));
   }
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -385,8 +385,13 @@ export default class LLVMCodeGen {
     return this.cgReturn.genReturnStatement(node);
   }
 
-  public genFunctionDeclaration(node: ts.FunctionDeclaration): llvm.Function {
-    return this.cgFuncDecl.genFunctionDeclaration(node);
+  public genFunctionDeclarationWithSignature(
+    node: ts.FunctionDeclaration,
+    args: llvm.Type[],
+    ret: llvm.Type,
+    hashName: string
+  ): llvm.Function {
+    return this.cgFuncDecl.genFunctionDeclarationWithSignature(node, args, ret, hashName);
   }
 
   public genIfStatement(node: ts.IfStatement): void {

--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -19,7 +19,7 @@ export default class GenObject {
   }
 
   public genObjectLiteralExpression(node: ts.ObjectLiteralExpression): llvm.Value {
-    const varName = (node.parent as ts.VariableDeclaration).name.getText();
+    const varName = ts.isVariableDeclaration(node.parent) ? node.parent.name.getText() : '';
     const values: llvm.Value[] = [];
     const types = [];
 
@@ -57,7 +57,6 @@ export default class GenObject {
     const field = node.name.getText();
     const index = fields!.get(field)!;
 
-    // const ptr = this.cgen.builder.createLoad(value);
     return this.cgen.builder.createInBoundsGEP(inner, [
       llvm.ConstantInt.get(this.cgen.context, 0, 32, true),
       llvm.ConstantInt.get(this.cgen.context, index, 32, true)

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -59,10 +59,64 @@ export function completionSuffix(s: string): string {
   return s.endsWith('.ts') ? s : s + '.ts';
 }
 
-function digestToHex(buf: Buffer | string): string {
+export function digestToHex(buf: Buffer | string): string {
   return crypto
     .createHash('md5')
     .update(buf)
     .digest()
     .toString('hex');
+}
+
+// Generate a function hash based on the function and the actual parameters passed.
+// This is designed for the duck type when a function is called.
+//
+// eg.
+// function echo(num: { num: number }): number {
+//   return num.num;
+// }
+//
+// function main(): number {
+//   echo({ num: 10 }); // ok
+//
+//   const obj1 = { num: 11, str: '12' };
+//   echo(obj1); // ok
+//
+//   const obj2 = { num: 12, str: '12', b: true };
+//   echo(obj2); // ok
+//
+//   return 1;
+// }
+//
+// Because each object type passed is inconsistent,
+// the LLVM IR layer generates a different function signature for each
+// call to echo, and the function hsah is the echo function to determine whether
+// the same parameters exist, so as to avoid repeated generation.
+//
+// TODO: Some boundaries are not handled, such as is it a reference to a reference?
+export function genFunctionHashWithCall(checker: ts.TypeChecker, call: ts.CallExpression): string {
+  const funcDecl = checker.getResolvedSignature(call)!.getDeclaration() as ts.FunctionDeclaration;
+
+  const code = funcDecl.getText();
+  const args = call.arguments;
+  const retType = funcDecl.type ? funcDecl.type : ts.createVoidZero();
+
+  const argStr = funcDecl.parameters
+    .map((param, index) => {
+      if (ts.isTypeLiteralNode(param.type!)) {
+        const arg = args[index];
+        if (ts.isIdentifier(arg)) {
+          const sym = checker.getSymbolAtLocation(arg)!;
+          const varObj = sym.valueDeclaration as ts.VariableDeclaration;
+          return (varObj.initializer! as ts.ObjectLiteralExpression).properties.map(p => p.kind).join('-');
+        } else if (ts.isObjectLiteralExpression(arg)) {
+          return arg.properties.map(p => p.kind).join('-');
+        }
+      }
+      return param.type!.kind + '';
+    })
+    .join('-');
+
+  const retStr = ts.isVoidExpression(retType) ? 'void' : retType.getText();
+
+  return digestToHex([code, argStr, retStr].join('-'));
 }

--- a/src/prepare/depends.ts
+++ b/src/prepare/depends.ts
@@ -1,7 +1,8 @@
 import ts from 'typescript';
 
+import * as common from '../common';
 import { StdFunc } from '../stdlib';
-import { NodeDepends } from '../types';
+import { DepType, NodeDepends } from '../types';
 
 export default class Depends {
   private readonly program: ts.Program;
@@ -39,15 +40,47 @@ export default class Depends {
     return this.scanFunc(main!)!;
   }
 
-  private scanFunc(node: ts.FunctionDeclaration): NodeDepends | null {
-    const dep: NodeDepends = { self: node, depends: [] };
+  private scanFunc(node: ts.FunctionDeclaration, call?: ts.CallExpression): NodeDepends | null {
+    const dep: NodeDepends = { self: node, depends: [], hashName: '', depType: DepType.func };
+
+    // If the function is not main,
+    // we need to calculate a summary of the function plus
+    // the call parameters to ensure that different function calls are generated for different types.
+    if (node.name && !call && node.name!.getText() === 'main') {
+      dep.hashName = 'main';
+      dep.depends = this.genMainParams(node);
+    } else if (node.name && call) {
+      dep.hashName = common.genFunctionHashWithCall(this.checker, call);
+    }
+
     if (!node.body) {
       return dep;
     }
 
-    dep.depends = this.findDepends(node, dep);
+    dep.depends = dep.depends.concat(this.findDepends(node, dep));
 
     return dep;
+  }
+
+  private genMainParams(node: ts.FunctionDeclaration): NodeDepends[] {
+    const deps: NodeDepends[] = [];
+
+    deps.push({
+      depType: DepType.retType,
+      depends: [],
+      hashName: '',
+      self: node.type ? node.type : ts.createVoidZero()
+    });
+    node.parameters.forEach(param => {
+      deps.push({
+        depType: DepType.paramType,
+        depends: [],
+        hashName: '',
+        self: param.type!
+      });
+    });
+
+    return deps;
   }
 
   private scanCallExpression(node: ts.CallExpression): NodeDepends | null {
@@ -57,7 +90,7 @@ export default class Depends {
     }
 
     const funcDecl = this.checker.getResolvedSignature(node)!.getDeclaration() as ts.FunctionDeclaration;
-    return this.scanFunc(funcDecl);
+    return this.scanFunc(funcDecl, node);
   }
 
   private findDepends(node: ts.Node, currentDep: NodeDepends): NodeDepends[] {
@@ -66,14 +99,15 @@ export default class Depends {
     node.forEachChild(subNode => {
       switch (subNode.kind) {
         case ts.SyntaxKind.CallExpression:
-          // Determines whether a function recursive call exists.
-          const funcDecl = this.checker.getResolvedSignature(subNode as ts.CallExpression)!.getDeclaration() as ts.Node;
-          if (funcDecl === currentDep.self) {
-            return;
+          const subHashName = common.genFunctionHashWithCall(this.checker, subNode as ts.CallExpression);
+          if (subHashName === currentDep.hashName) {
+            break;
           }
 
           const dep = this.scanCallExpression(subNode as ts.CallExpression);
           if (dep) {
+            // Specify the dependency type for the function up front.
+            dep.depends = dep.depends.concat(this.genCallExpressionDepends(subNode as ts.CallExpression));
             deps.push(dep);
           }
           break;
@@ -84,5 +118,97 @@ export default class Depends {
     });
 
     return deps;
+  }
+
+  private genCallExpressionDepends(node: ts.CallExpression): NodeDepends[] {
+    const deps: NodeDepends[] = [];
+
+    // function args type
+    node.arguments.forEach(arg => {
+      deps.push({ self: this.genExpression(arg), depends: [], hashName: '', depType: DepType.paramType });
+    });
+
+    // function return type
+    const funcDecl = this.checker.getResolvedSignature(node)!.getDeclaration() as ts.FunctionDeclaration;
+    if (funcDecl.type) {
+      deps.push({ self: funcDecl.type as ts.Node, depends: [], hashName: '', depType: DepType.retType });
+    }
+
+    return deps.filter(dep => dep !== null);
+  }
+
+  private genExpression(node: ts.Expression): ts.TypeNode {
+    switch (node.kind) {
+      case ts.SyntaxKind.Identifier:
+        return this.genIdentifier(node as ts.Identifier);
+      case ts.SyntaxKind.ObjectLiteralExpression:
+        return this.genObjectTypeLiteral(node as ts.ObjectLiteralExpression);
+      case ts.SyntaxKind.ArrayLiteralExpression:
+        return this.genArrayLiteralExpression(node as ts.ArrayLiteralExpression);
+
+      // Enum only support `string` and `number`.
+      case ts.SyntaxKind.PropertyAccessExpression:
+        const val = this.checker.getConstantValue(node as ts.PropertyAccessExpression);
+        if (typeof val === 'string') {
+          return this.primitiveToTypeNode(ts.SyntaxKind.StringLiteral);
+        }
+        return this.primitiveToTypeNode(ts.SyntaxKind.NumericLiteral);
+      default:
+        return this.primitiveToTypeNode(node.kind);
+    }
+  }
+
+  private genIdentifier(iden: ts.Identifier): ts.TypeNode {
+    const nodeSymbol = this.checker.getSymbolAtLocation(iden)!;
+    const varObj = nodeSymbol.valueDeclaration as ts.VariableDeclaration;
+
+    return this.genExpression(varObj.initializer!);
+  }
+
+  private genObjectTypeLiteral(node: ts.ObjectLiteralExpression): ts.TypeNode {
+    const args: ReadonlyArray<ts.TypeElement> = node.properties.map(p => {
+      const parameterType = this.checker.getTypeAtLocation(p);
+      const sig = ts.createPropertySignature(
+        undefined,
+        p.name!,
+        undefined,
+        this.checker.typeToTypeNode(parameterType),
+        undefined
+      );
+      return sig;
+    });
+
+    return ts.createTypeLiteralNode(args);
+  }
+
+  private genArrayLiteralExpression(node: ts.ArrayLiteralExpression): ts.TypeNode {
+    let typeNode: ts.TypeNode | null = null;
+    node.elements.forEach(item => {
+      const nextType = this.genExpression(item);
+      if (typeNode) {
+        // TODO: Need to handle 'const arr = [call(1), 1]'?
+        if (typeNode.kind !== nextType.kind) {
+          throw new Error('The element types of the array must be consistent.');
+        }
+      } else {
+        typeNode = nextType;
+      }
+    });
+
+    return ts.createArrayTypeNode(typeNode ? typeNode : ts.createNull());
+  }
+
+  private primitiveToTypeNode(kind: ts.SyntaxKind): ts.TypeNode {
+    switch (kind) {
+      case ts.SyntaxKind.NumericLiteral:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+      case ts.SyntaxKind.StringLiteral:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+      case ts.SyntaxKind.TrueKeyword:
+      case ts.SyntaxKind.FalseKeyword:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+      default:
+        throw new Error(`Unsupported primitive types ${kind}`);
+    }
   }
 }

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -88,6 +88,15 @@ class Symtab {
   }
 
   public get(key: string): Value {
+    const value = this.tryGet(key);
+    if (value) {
+      return value;
+    }
+
+    throw new Error(`Symbol ${key} not found`);
+  }
+
+  public tryGet(key: string): Value | null {
     let n: Scope = this.data;
 
     while (true) {
@@ -99,7 +108,7 @@ class Symtab {
       if (n.parent) {
         n = n.parent;
       } else {
-        throw new Error(`Symbol ${key} not found`);
+        return null;
       }
     }
   }

--- a/src/tests/object.spec.ts
+++ b/src/tests/object.spec.ts
@@ -75,3 +75,36 @@ test('test object return string', async t => {
 
   t.pass();
 });
+
+test('test object duck type', async t => {
+  await runCode(
+    `
+    function echo(num: { num: number }): number {
+      return num.num;
+    }
+
+    function main(): number {
+      const val0 = echo({ num: 10 });
+      if (val0 !== 10) {
+        return 1;
+      }
+
+      const obj1 = { num: 11, str: '12' };
+      const val1 = echo(obj1);
+      if (val1 !== 11) {
+        return 1;
+      }
+
+      const obj2 = { num: 12, str: '12', b: true };
+      const val2 = echo(obj2);
+      if (val2 !== 12) {
+        return 1;
+      }
+
+      return 0;
+    }
+    `
+  );
+
+  t.pass();
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,15 @@ export interface StructMeta {
   struct: llvm.StructType;
 }
 
+export enum DepType {
+  func = 0,
+  paramType = 1,
+  retType = 2
+}
+
 export interface NodeDepends {
   self: ts.Node;
+  hashName: string;
+  depType: DepType;
   depends: NodeDepends[];
 }


### PR DESCRIPTION
## Describe
The following types of parameter passing are supported in native typescript.
````ts
function echo(num: { num: number }): number {
  return num.num;
}

function main(): number {
  const val0 = echo({ num: 10 });
  if (val0 !== 10) {
    return 1;
  }

  const obj1 = { num: 11, str: '12' };
  const val1 = echo(obj1);
  if (val1 !== 11) {
    return 1;
  }

  const obj2 = { num: 12, str: '12', b: true };
  const val2 = echo(obj2);
  if (val2 !== 12) {
    return 1;
  }

  return 0;
}
````
The call to the above three `echo` is legal. That is, as long as the type and name of the passed parameters match the function signature, they are treated as legitimate calls.

So, this PR is just to make `minits` have the same characteristics.

## How to support?
In short, supporting this feature requires several steps:

1. Before `code gen`, start scanning all entries of the called function and its dependencies (signatures, parameters, function calls) from `main`.
2. Regenerate the function signature dependency for each function and generate the function's `hashName` (possibly duplicated)
3. In the `code gen` with main as the entry, from bottom to top LLVM IR.

## LLVM IR
````ll
; ModuleID = 'main'
source_filename = "examples/foo.ts"
target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin18.6.0"

%"6512bd43d9caa6e02c990b0a82652dca" = type { i64 }
%b40292fd5091e1b9132b8aecc2c9efc2 = type { i64, i8* }
%"76b501d2997290dd635864d6adafc639" = type { i64, i8*, i1 }

@.str = private unnamed_addr constant [3 x i8] c"12\00", align 1
@.str.1 = private unnamed_addr constant [3 x i8] c"12\00", align 1

define i64 @dd7edeac8bbcc8a70436a2870894e3ef(%"6512bd43d9caa6e02c990b0a82652dca"* %num) {
body:
  %0 = getelementptr inbounds %"6512bd43d9caa6e02c990b0a82652dca", %"6512bd43d9caa6e02c990b0a82652dca"* %num, i32 0, i32 0
  %1 = load i64, i64* %0
  ret i64 %1
}

define i64 @a81fa66509a0b1163dccf73b37d4ac5f(%b40292fd5091e1b9132b8aecc2c9efc2* %num) {
body:
  %0 = getelementptr inbounds %b40292fd5091e1b9132b8aecc2c9efc2, %b40292fd5091e1b9132b8aecc2c9efc2* %num, i32 0, i32 0
  %1 = load i64, i64* %0
  ret i64 %1
}

define i64 @d0cc410519e80b907dc380cf0e44f813(%"76b501d2997290dd635864d6adafc639"* %num) {
body:
  %0 = getelementptr inbounds %"76b501d2997290dd635864d6adafc639", %"76b501d2997290dd635864d6adafc639"* %num, i32 0, i32 0
  %1 = load i64, i64* %0
  ret i64 %1
}

; Function Attrs: noinline optnone
define i64 @main() #0 {
body:
  %0 = alloca %"6512bd43d9caa6e02c990b0a82652dca"
  store %"6512bd43d9caa6e02c990b0a82652dca" { i64 10 }, %"6512bd43d9caa6e02c990b0a82652dca"* %0
  %1 = call i64 @dd7edeac8bbcc8a70436a2870894e3ef(%"6512bd43d9caa6e02c990b0a82652dca"* %0)
  %val0 = alloca i64
  store i64 %1, i64* %val0
  %2 = load i64, i64* %val0
  %3 = icmp ne i64 %2, 10
  br i1 %3, label %if.then, label %if.else

if.then:                                          ; preds = %body
  ret i64 1

if.else:                                          ; preds = %body
  br label %if.quit

if.quit:                                          ; preds = %if.else
  %obj1 = alloca %b40292fd5091e1b9132b8aecc2c9efc2
  store %b40292fd5091e1b9132b8aecc2c9efc2 { i64 11, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.str, i32 0, i32 0) }, %b40292fd5091e1b9132b8aecc2c9efc2* %obj1
  %4 = call i64 @a81fa66509a0b1163dccf73b37d4ac5f(%b40292fd5091e1b9132b8aecc2c9efc2* %obj1)
  %val1 = alloca i64
  store i64 %4, i64* %val1
  %5 = load i64, i64* %val1
  %6 = icmp ne i64 %5, 11
  br i1 %6, label %if.then1, label %if.else2

if.then1:                                         ; preds = %if.quit
  ret i64 1

if.else2:                                         ; preds = %if.quit
  br label %if.quit3

if.quit3:                                         ; preds = %if.else2
  %obj2 = alloca %"76b501d2997290dd635864d6adafc639"
  store %"76b501d2997290dd635864d6adafc639" { i64 12, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.str.1, i32 0, i32 0), i1 true }, %"76b501d2997290dd635864d6adafc639"* %obj2
  %7 = call i64 @d0cc410519e80b907dc380cf0e44f813(%"76b501d2997290dd635864d6adafc639"* %obj2)
  %val2 = alloca i64
  store i64 %7, i64* %val2
  %8 = load i64, i64* %val2
  %9 = icmp ne i64 %8, 12
  br i1 %9, label %if.then4, label %if.else5

if.then4:                                         ; preds = %if.quit3
  ret i64 1

if.else5:                                         ; preds = %if.quit3
  br label %if.quit6

if.quit6:                                         ; preds = %if.else5
  ret i64 0
}

attributes #0 = { noinline optnone }
````