### PR TITLE
Implement for-of-statement for string

### DIFF
--- a/src/codegen/array-literal-expression.ts
+++ b/src/codegen/array-literal-expression.ts
@@ -85,19 +85,20 @@ export default class CodeGenArray {
     return r;
   }
 
-  public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
-    const identifier = this.cgen.genExpression(node.expression);
-    const argumentExpression = this.cgen.genExpression(node.argumentExpression);
+  public getElementAccess(identifier: llvm.Value, i: llvm.Value): llvm.Value {
     const ptr = (() => {
       if ((identifier.type as llvm.PointerType).elementType.isArrayTy()) {
-        return this.cgen.builder.createInBoundsGEP(identifier, [
-          llvm.ConstantInt.get(this.cgen.context, 0, 64),
-          argumentExpression
-        ]);
+        return this.cgen.builder.createInBoundsGEP(identifier, [llvm.ConstantInt.get(this.cgen.context, 0, 64), i]);
       } else {
-        return this.cgen.builder.createInBoundsGEP(identifier, [argumentExpression]);
+        return this.cgen.builder.createInBoundsGEP(identifier, [i]);
       }
     })();
     return this.cgen.builder.createLoad(ptr);
+  }
+
+  public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
+    const identifier = this.cgen.genExpression(node.expression);
+    const argumentExpression = this.cgen.genExpression(node.argumentExpression);
+    return this.getElementAccess(identifier, argumentExpression);
   }
 }

--- a/src/codegen/element-access-expression.ts
+++ b/src/codegen/element-access-expression.ts
@@ -11,11 +11,20 @@ export default class CodeGenElemAccess {
   }
 
   public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
-    const symbol = this.cgen.checker.getSymbolAtLocation(node.expression)!;
-    const type = this.cgen.checker.getTypeOfSymbolAtLocation(symbol, node.expression);
-    if (type.flags === ts.TypeFlags.String) {
-      return this.cgen.cgString.genElementAccess(node);
+    if (node.expression.kind === ts.SyntaxKind.Identifier) {
+      const symbol = this.cgen.checker.getSymbolAtLocation(node.expression)!;
+      const type = this.cgen.checker.getTypeOfSymbolAtLocation(symbol, node.expression);
+      if (type.flags === ts.TypeFlags.String) {
+        return this.cgen.cgString.genElementAccess(node);
+      }
+      return this.cgen.cgArray.genElementAccess(node);
     }
-    return this.cgen.cgArray.genElementAccess(node);
+
+    const identifer = this.cgen.genExpression(node.expression);
+    const argumentExpression = this.cgen.genExpression(node.argumentExpression);
+    if (node.expression.kind === ts.SyntaxKind.StringLiteral) {
+      return this.cgen.cgString.getElementAccess(identifer, argumentExpression);
+    }
+    return this.cgen.cgArray.getElementAccess(identifer, argumentExpression);
   }
 }

--- a/src/codegen/element-access-expression.ts
+++ b/src/codegen/element-access-expression.ts
@@ -11,18 +11,17 @@ export default class CodeGenElemAccess {
   }
 
   public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
-    if (node.expression.kind === ts.SyntaxKind.Identifier) {
-      const symbol = this.cgen.checker.getSymbolAtLocation(node.expression)!;
-      const type = this.cgen.checker.getTypeOfSymbolAtLocation(symbol, node.expression);
-      if (type.flags === ts.TypeFlags.String) {
-        return this.cgen.cgString.genElementAccess(node);
+    const isTypeString = (() => {
+      if (node.expression.kind === ts.SyntaxKind.Identifier) {
+        const symbol = this.cgen.checker.getSymbolAtLocation(node.expression)!;
+        const type = this.cgen.checker.getTypeOfSymbolAtLocation(symbol, node.expression);
+        return type.flags === ts.TypeFlags.String;
       }
-      return this.cgen.cgArray.genElementAccess(node);
-    }
-
+      return node.expression.kind === ts.SyntaxKind.StringLiteral;
+    })();
     const identifer = this.cgen.genExpression(node.expression);
     const argumentExpression = this.cgen.genExpression(node.argumentExpression);
-    if (node.expression.kind === ts.SyntaxKind.StringLiteral) {
+    if (isTypeString) {
       return this.cgen.cgString.getElementAccess(identifer, argumentExpression);
     }
     return this.cgen.cgArray.getElementAccess(identifer, argumentExpression);

--- a/src/codegen/for-of-statement.ts
+++ b/src/codegen/for-of-statement.ts
@@ -11,6 +11,54 @@ export default class CodeGenForOf {
     this.cgen = cgen;
   }
 
+  public genForOfStatementString(node: ts.ForOfStatement): void {
+    const pi = (() => {
+      const name = 'loop.i';
+      const initializer = llvm.ConstantInt.get(this.cgen.context, 0, 64);
+      const type = initializer.type;
+      const alloca = this.cgen.builder.createAlloca(type, undefined, name);
+      this.cgen.builder.createStore(initializer, alloca);
+      this.cgen.symtab.set(name, new symtab.LLVMValue(alloca, 1));
+      return alloca;
+    })();
+    const identifier = this.cgen.genExpression(node.expression) as llvm.AllocaInst;
+    const pv = (() => {
+      const name = (node.initializer! as ts.VariableDeclarationList).declarations!.map(item => item.getText())[0];
+      const alloca = this.cgen.builder.createAlloca(llvm.Type.getInt8PtrTy(this.cgen.context), undefined, name);
+      this.cgen.symtab.set(name, new symtab.LLVMValue(alloca, 1));
+      return alloca;
+    })();
+
+    const loopCond = llvm.BasicBlock.create(this.cgen.context, 'loop.cond', this.cgen.currentFunction);
+    const loopBody = llvm.BasicBlock.create(this.cgen.context, 'loop.body', this.cgen.currentFunction);
+    const loopIncr = llvm.BasicBlock.create(this.cgen.context, 'loop.incr', this.cgen.currentFunction);
+    const loopQuit = llvm.BasicBlock.create(this.cgen.context, 'loop.quit', this.cgen.currentFunction);
+
+    const l = this.cgen.stdlib.strlen([identifier]);
+    this.cgen.builder.createBr(loopCond);
+    this.cgen.builder.setInsertionPoint(loopCond);
+    const cond = this.cgen.builder.createICmpSLT(this.cgen.builder.createLoad(pi), l);
+    this.cgen.builder.createCondBr(cond, loopBody, loopQuit);
+
+    this.cgen.builder.setInsertionPoint(loopBody);
+    const v = this.cgen.cgString.getElementAccess(identifier, this.cgen.builder.createLoad(pi));
+    this.cgen.builder.createStore(v, pv);
+
+    this.cgen.withContinueBreakBlock(loopIncr, loopQuit, () => {
+      this.cgen.genStatement(node.statement);
+    });
+    this.cgen.builder.createBr(loopIncr);
+
+    this.cgen.builder.setInsertionPoint(loopIncr);
+    const n = this.cgen.builder.createAdd(
+      this.cgen.builder.createLoad(pi),
+      llvm.ConstantInt.get(this.cgen.context, 1, 64)
+    );
+    this.cgen.builder.createStore(n, pi);
+    this.cgen.builder.createBr(loopCond);
+    this.cgen.builder.setInsertionPoint(loopQuit);
+  }
+
   public genForOfStatementArray(node: ts.ForOfStatement): void {
     const pi = (() => {
       const name = 'loop.i';
@@ -34,8 +82,8 @@ export default class CodeGenForOf {
     const loopIncr = llvm.BasicBlock.create(this.cgen.context, 'loop.incr', this.cgen.currentFunction);
     const loopQuit = llvm.BasicBlock.create(this.cgen.context, 'loop.quit', this.cgen.currentFunction);
 
-    this.cgen.builder.createBr(loopCond);
     const l = llvm.ConstantInt.get(this.cgen.context, (identifier.type.elementType as llvm.ArrayType).numElements, 64);
+    this.cgen.builder.createBr(loopCond);
     this.cgen.builder.setInsertionPoint(loopCond);
     const cond = this.cgen.builder.createICmpSLT(this.cgen.builder.createLoad(pi), l);
     this.cgen.builder.createCondBr(cond, loopBody, loopQuit);
@@ -55,10 +103,7 @@ export default class CodeGenForOf {
       llvm.ConstantInt.get(this.cgen.context, 1, 64)
     );
     this.cgen.builder.createStore(n, pi);
-    const ptr = this.cgen.builder.createInBoundsGEP(identifier, [llvm.ConstantInt.get(this.cgen.context, 0, 64), n]);
-    this.cgen.builder.createStore(this.cgen.builder.createLoad(ptr), pv);
     this.cgen.builder.createBr(loopCond);
-
     this.cgen.builder.setInsertionPoint(loopQuit);
   }
 
@@ -72,8 +117,9 @@ export default class CodeGenForOf {
       return node.expression.kind === ts.SyntaxKind.StringLiteral;
     })();
     if (isTypeString) {
-      throw new Error('lll');
+      return this.genForOfStatementString(node);
+    } else {
+      return this.genForOfStatementArray(node);
     }
-    return this.genForOfStatementArray(node);
   }
 }

--- a/src/codegen/for-of-statement.ts
+++ b/src/codegen/for-of-statement.ts
@@ -11,7 +11,7 @@ export default class CodeGenForOf {
     this.cgen = cgen;
   }
 
-  public genForOfStatement(node: ts.ForOfStatement): void {
+  public genForOfStatementArray(node: ts.ForOfStatement): void {
     const pi = (() => {
       const name = 'loop.i';
       const initializer = llvm.ConstantInt.get(this.cgen.context, 0, 64);
@@ -60,5 +60,20 @@ export default class CodeGenForOf {
     this.cgen.builder.createBr(loopCond);
 
     this.cgen.builder.setInsertionPoint(loopQuit);
+  }
+
+  public genForOfStatement(node: ts.ForOfStatement): void {
+    const isTypeString = (() => {
+      if (node.expression.kind === ts.SyntaxKind.Identifier) {
+        const symbol = this.cgen.checker.getSymbolAtLocation(node.expression)!;
+        const type = this.cgen.checker.getTypeOfSymbolAtLocation(symbol, node.expression);
+        return type.flags === ts.TypeFlags.String;
+      }
+      return node.expression.kind === ts.SyntaxKind.StringLiteral;
+    })();
+    if (isTypeString) {
+      throw new Error('lll');
+    }
+    return this.genForOfStatementArray(node);
   }
 }

--- a/src/codegen/for-of-statement.ts
+++ b/src/codegen/for-of-statement.ts
@@ -41,11 +41,7 @@ export default class CodeGenForOf {
     this.cgen.builder.createCondBr(cond, loopBody, loopQuit);
 
     this.cgen.builder.setInsertionPoint(loopBody);
-    const p = this.cgen.builder.createInBoundsGEP(a, [
-      llvm.ConstantInt.get(this.cgen.context, 0, 64),
-      this.cgen.builder.createLoad(i)
-    ]);
-    this.cgen.builder.createStore(this.cgen.builder.createLoad(p), v);
+    this.cgen.builder.createStore(this.cgen.cgArray.getElementAccess(a, i), v);
 
     this.cgen.withContinueBreakBlock(loopIncr, loopQuit, () => {
       this.cgen.genStatement(node.statement);

--- a/src/codegen/function-declaration.ts
+++ b/src/codegen/function-declaration.ts
@@ -43,7 +43,7 @@ export default class CodeGenFuncDecl {
         this.cgen.builder.setInsertionPoint(body);
         this.cgen.withFunction(func, () => {
           this.cgen.genBlock(node.body!);
-          if (!body.getTerminator()) {
+          if (!this.cgen.builder.getInsertBlock()!.getTerminator()) {
             this.cgen.builder.createRetVoid();
           }
         });

--- a/src/codegen/string-literal-expression.ts
+++ b/src/codegen/string-literal-expression.ts
@@ -38,10 +38,8 @@ export default class CodeGenString {
     return this.cgen.builder.createBitCast(r, llvm.Type.getInt8PtrTy(this.cgen.context));
   }
 
-  public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
-    const identifier = this.cgen.genExpression(node.expression);
-    const argumentExpression = this.cgen.genExpression(node.argumentExpression);
-    const ptr = this.cgen.builder.createInBoundsGEP(identifier, [argumentExpression]);
+  public getElementAccess(identifier: llvm.Value, i: llvm.Value): llvm.Value {
+    const ptr = this.cgen.builder.createInBoundsGEP(identifier, [i]);
     const val = this.cgen.builder.createLoad(ptr);
 
     const arrayType = llvm.ArrayType.get(llvm.Type.getInt8Ty(this.cgen.context), 2);
@@ -59,6 +57,12 @@ export default class CodeGenString {
     this.cgen.builder.createStore(val, ptr0);
     this.cgen.builder.createStore(llvm.ConstantInt.get(this.cgen.context, 0, 8), ptr1);
     return this.cgen.builder.createBitCast(arrayPtr, llvm.Type.getInt8PtrTy(this.cgen.context));
+  }
+
+  public genElementAccess(node: ts.ElementAccessExpression): llvm.Value {
+    const identifier = this.cgen.genExpression(node.expression);
+    const argumentExpression = this.cgen.genExpression(node.argumentExpression);
+    return this.getElementAccess(identifier, argumentExpression);
   }
 
   public eq(lhs: llvm.Value, rhs: llvm.Value): llvm.Value {

--- a/src/tests/element-access-expression.spec.ts
+++ b/src/tests/element-access-expression.spec.ts
@@ -1,0 +1,43 @@
+import test from 'ava';
+import { runCode } from './util';
+
+const srcArray = `
+let globalarr = [1, 2, 3];
+
+function main(): number {
+    let localearr = [4, 5, 6];
+    let s: number = 0;
+    s += globalarr[0];
+    s += localearr[0];
+    s += [1, 2, 3][0];
+    return s; // 6
+}
+`;
+
+test('test element access array', async t => {
+  await runCode(srcArray);
+  t.pass();
+});
+
+const srcString = `
+let globalstr = "Hello";
+
+function main(): number {
+  let localestr = "Hello";
+  if (globalstr[0] !== "H") {
+    return 1;
+  }
+  if (localestr[0] !== "H") {
+    return 1;
+  }
+  if ("Hello"[0] !== "H") {
+    return 1;
+  }
+  return 0;
+}
+`;
+
+test('test element access string', async t => {
+  await runCode(srcString);
+  t.pass();
+});

--- a/src/tests/for-of-statement.spec.ts
+++ b/src/tests/for-of-statement.spec.ts
@@ -14,10 +14,13 @@ function main(): number {
     for (let v of localearr) {
         s += v;
     }
+    for (let v of [1, 2, 3]) {
+        s += v;
+    }
     for (let v of emptyarr) {
         s += v;
     }
-    return s; // 21
+    return s; // 27
 }
 `;
 

--- a/src/tests/for-of-statement.spec.ts
+++ b/src/tests/for-of-statement.spec.ts
@@ -1,0 +1,27 @@
+import test from 'ava';
+import { runCode } from './util';
+
+const srcForOfArray = `
+let globalarr = [1, 2, 3];
+
+function main(): number {
+    let localearr = [4, 5, 6];
+    let emptyarr: number[] = [];
+    let s: number = 0;
+    for (let v of globalarr) {
+        s += v;
+    }
+    for (let v of localearr) {
+        s += v;
+    }
+    for (let v of emptyarr) {
+        s += v;
+    }
+    return s; // 21
+}
+`;
+
+test('test statement for of', async t => {
+  await runCode(srcForOfArray);
+  t.pass();
+});

--- a/src/tests/for-of-statement.spec.ts
+++ b/src/tests/for-of-statement.spec.ts
@@ -24,7 +24,29 @@ function main(): number {
 }
 `;
 
-test('test statement for of', async t => {
+test('test for of array', async t => {
   await runCode(srcForOfArray);
+  t.pass();
+});
+
+const srcForOfString = `
+function main(): number {
+    let a = "Hello";
+    let s = "";
+    for (let i of a) {
+        s = s + i;
+    }
+    for (let i of "World") {
+        s = s + i;
+    }
+    if (s !== "HelloWorld") {
+        return 1;
+    }
+    return 0;
+}
+`;
+
+test('test for of string', async t => {
+  await runCode(srcForOfString);
   t.pass();
 });

--- a/src/tests/statement.sepc.ts
+++ b/src/tests/statement.sepc.ts
@@ -116,32 +116,6 @@ test('test statement for loop', async t => {
   t.pass();
 });
 
-test('test statement for of', async t => {
-  await runCode(
-    `
-    let globalarr = [1, 2, 3];
-
-    function main(): number {
-        let localearr = [4, 5, 6];
-        let emptyarr: number[] = [];
-        let s: number = 0;
-        for (let v of globalarr) {
-            s += v;
-        }
-        for (let v of localearr) {
-            s += v;
-        }
-        for (let v of emptyarr) {
-            s += v;
-        }
-        return s; // 21
-    }
-    `
-  );
-
-  t.pass();
-});
-
 test('test statement logic and or', async t => {
   await runCode(
     `


### PR DESCRIPTION
```ts
for (let i of "Hello") {
  console.log("%s\n", i); // "H", "e", "l", "l", "o"
}
```

**IR**

```
; ModuleID = 'main'
source_filename = "examples/foo.ts"
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

@.str = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
@.str.1 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1

; Function Attrs: noinline optnone
define i64 @main() #0 {
body:
  %loop.i = alloca i64
  store i64 0, i64* %loop.i
  %i = alloca i8*
  %0 = call i64 @strlen(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i32 0, i32 0))
  br label %loop.cond

loop.cond:                                        ; preds = %loop.incr, %body
  %1 = load i64, i64* %loop.i
  %2 = icmp slt i64 %1, %0
  br i1 %2, label %loop.body, label %loop.quit

loop.body:                                        ; preds = %loop.cond
  %3 = load i64, i64* %loop.i
  %4 = getelementptr inbounds i8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str, i32 0, i32 0), i64 %3
  %5 = load i8, i8* %4
  %6 = alloca [2 x i8], i64 2
  %7 = getelementptr inbounds [2 x i8], [2 x i8]* %6, i64 0, i64 0
  %8 = getelementptr inbounds [2 x i8], [2 x i8]* %6, i64 0, i64 1
  store i8 %5, i8* %7
  store i8 0, i8* %8
  %9 = bitcast [2 x i8]* %6 to i8*
  store i8* %9, i8** %i
  %10 = load i8*, i8** %i
  %11 = call i64 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str.1, i32 0, i32 0), i8* %10)
  br label %loop.incr

loop.incr:                                        ; preds = %loop.body
  %12 = load i64, i64* %loop.i
  %13 = add i64 %12, 1
  store i64 %13, i64* %loop.i
  br label %loop.cond

loop.quit:                                        ; preds = %loop.cond
  ret i64 0
}

declare i64 @strlen(i8*)

declare i64 @printf(i8*, ...)

attributes #0 = { noinline optnone }
```