### PR TITLE
Remove .fields in symtab.LLVMValue

### DIFF
--- a/src/codegen/object-declaration.ts
+++ b/src/codegen/object-declaration.ts
@@ -53,11 +53,12 @@ export default class GenObject {
   }
 
   public genObjectElementAccessPtr(node: ts.PropertyAccessExpression): llvm.Value {
-    const { inner, fields } = this.cgen.symtab.get(node.expression.getText()) as symtab.LLVMValue;
-    const field = node.name.getText();
-    const index = fields!.get(field)!;
+    const type = this.cgen.checker.getTypeAtLocation(node.expression);
+    const properties = this.cgen.checker.getPropertiesOfType(type);
+    const index = properties.findIndex(property => property.name === node.name.getText());
+    const value = this.cgen.symtab.get(node.expression.getText()) as symtab.LLVMValue;
 
-    return this.cgen.builder.createInBoundsGEP(inner, [
+    return this.cgen.builder.createInBoundsGEP(value.inner, [
       llvm.ConstantInt.get(this.cgen.context, 0, 32, true),
       llvm.ConstantInt.get(this.cgen.context, index, 32, true)
     ]);

--- a/src/codegen/variable-declaration.ts
+++ b/src/codegen/variable-declaration.ts
@@ -38,18 +38,7 @@ export default class CodeGenArray {
     // ObjectLiteral
     const realType = common.findRealType(type);
     if (realType.isStructTy()) {
-      let fields: Map<string, number> = new Map();
-
-      // If the variable is a function return value, get the field information for the return value.
-      if (ts.isCallExpression(node.initializer!)) {
-        const funcName = (node.initializer! as ts.CallExpression).expression.getText();
-        const v = this.cgen.symtab.get(funcName)! as symtab.LLVMValue;
-        fields = v.fields!;
-      } else {
-        fields = common.buildStructMaps(realType, node.initializer! as ts.ObjectLiteralExpression);
-      }
-
-      this.cgen.symtab.set(name, new symtab.LLVMValue(initializer, 0, fields));
+      this.cgen.symtab.set(name, new symtab.LLVMValue(initializer, 0));
       return initializer;
     }
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -29,28 +29,6 @@ export function findRealType(t: llvm.Type): llvm.Type {
   return t;
 }
 
-export function buildStructMaps(
-  struct: llvm.StructType,
-  node: ts.ObjectLiteralExpression | ts.TypeLiteralNode
-): Map<string, number> {
-  let fieldNames: string[] = [];
-
-  if (ts.isObjectLiteralExpression(node)) {
-    fieldNames = node.properties.map(p => (p.name as ts.Identifier).getText());
-  } else if (ts.isTypeLiteralNode(node)) {
-    fieldNames = node.members.map(m => m.name!.getText());
-  } else {
-    throw new Error(`Kind not supported.`);
-  }
-
-  const fields: Map<string, number> = new Map();
-  Array.from({ length: (findRealType(struct) as llvm.StructType).numElements }).forEach((_, index) =>
-    fields.set(fieldNames[index], index)
-  );
-
-  return fields;
-}
-
 export function digestToHex(buf: Buffer | string): string {
   return crypto
     .createHash('md5')

--- a/src/symtab.ts
+++ b/src/symtab.ts
@@ -7,14 +7,10 @@ interface Value {
 class LLVMValue implements Value {
   public readonly inner: llvm.Value;
   public readonly deref: number;
-  // If the type of type is a struct, fields are the fields contained in the struct
-  // If the type of  is a function and the return value is an object, fields is the field of the object.
-  public readonly fields?: Map<string, number>;
 
-  constructor(inner: llvm.Value, deref: number, fields?: Map<string, number>) {
+  constructor(inner: llvm.Value, deref: number) {
     this.inner = inner;
     this.deref = deref;
-    this.fields = fields;
   }
 }
 


### PR DESCRIPTION
Meaningless code which can be replaced with ts.TypeChecker.