### PR TITLE
Add grammar new Buffer([1, 2, 3...])

### DIFF
--- a/src/codegen/new-expression.ts
+++ b/src/codegen/new-expression.ts
@@ -15,13 +15,42 @@ export default class CodeGenNew {
       const name = (node.expression as ts.Identifier).getText();
       switch (name) {
         case 'Buffer':
-          const n = parseInt((node.arguments![0] as ts.NumericLiteral).getText(), 10);
-          const arrayType = llvm.ArrayType.get(llvm.Type.getInt8Ty(this.cgen.context), n);
-          const arrayPtr = this.cgen.builder.createAlloca(arrayType);
-          return this.cgen.builder.createInBoundsGEP(arrayPtr, [
-            llvm.ConstantInt.get(this.cgen.context, 0, 64),
-            llvm.ConstantInt.get(this.cgen.context, 0, 64)
-          ]);
+          switch (node.arguments![0].kind) {
+            case ts.SyntaxKind.NumericLiteral:
+              const n = parseInt((node.arguments![0] as ts.NumericLiteral).getText(), 10);
+              const arrayType = llvm.ArrayType.get(llvm.Type.getInt8Ty(this.cgen.context), n);
+              const arrayPtr = this.cgen.builder.createAlloca(arrayType);
+              return this.cgen.builder.createInBoundsGEP(arrayPtr, [
+                llvm.ConstantInt.get(this.cgen.context, 0, 64),
+                llvm.ConstantInt.get(this.cgen.context, 0, 64)
+              ]);
+            case ts.SyntaxKind.ArrayLiteralExpression:
+              return (() => {
+                const expr = node.arguments![0] as ts.ArrayLiteralExpression;
+                const l = expr.elements.length;
+                const arrayType = llvm.ArrayType.get(llvm.Type.getInt8Ty(this.cgen.context), l);
+                const arrayPtr = this.cgen.builder.createAlloca(arrayType);
+                for (let i = 0; i < l; i++) {
+                  const item = this.cgen.builder.createIntCast(
+                    this.cgen.genExpression(expr.elements[i]),
+                    llvm.Type.getInt8Ty(this.cgen.context),
+                    true
+                  );
+
+                  const ptr = this.cgen.builder.createInBoundsGEP(arrayPtr, [
+                    llvm.ConstantInt.get(this.cgen.context, 0, 64),
+                    llvm.ConstantInt.get(this.cgen.context, i, 64)
+                  ]);
+                  this.cgen.builder.createStore(item, ptr);
+                }
+                return this.cgen.builder.createInBoundsGEP(arrayPtr, [
+                  llvm.ConstantInt.get(this.cgen.context, 0, 64),
+                  llvm.ConstantInt.get(this.cgen.context, 0, 64)
+                ]);
+              })();
+            default:
+              throw new Error('Upsupported grammar');
+          }
         default:
           throw new Error('Unsupported struct');
       }

--- a/src/tests/buffer.spec.ts
+++ b/src/tests/buffer.spec.ts
@@ -8,4 +8,12 @@ function main(): number {
 }
 `;
 
+const srcNewWithNumberArray = `
+function main(): number {
+    let a = new Buffer([1, 2000, 3]);
+    return a[1];
+}
+`;
+
 runTest('test buffer: get and set', srcGetAndSet);
+runTest('test buffer: new with number array', srcNewWithNumberArray);


### PR DESCRIPTION
Example:

```ts
function main(): number {
    let a = new Buffer([1, 2000, 3]);
    return a[1]; // returns 2000 / 256
}
```

The current implementation is not very good, but I have to add this feature as soon as possible.

#74 